### PR TITLE
Improve intro branding. Add status info

### DIFF
--- a/en/README.md
+++ b/en/README.md
@@ -15,7 +15,7 @@ The library provides a simple API for managing one or more vehicles, providing p
 
 The library can run on a vehicle-based companion computer or on a ground-based GCS or mobile device (these devices have significantly more processing power that an ordinary flight controller, enabling tasks like computer vision, obstacle avoidance, and route planning).
 
-Developers can extend the core C++ SDK using plugins in order to add any other required MAVLink API (for example, to integrate PX4 with custom cameras, gimbals, or other hardware over MAVLink).
+Developers can extend the core C++ SDK using plugins in order to add any other required MAVLink API (for example, to integrate a flight controller with custom cameras, gimbals, or other hardware over MAVLink).
 
 Cross-platform wrappers for the core library are actively being developed.
 These (primarily) use [gRPC](https://grpc.io/) and [Reactive Extensions](http://reactivex.io/).
@@ -31,14 +31,13 @@ The MAVSDK is a robust and well-tested library that is already in use in product
 
 ## Getting Started
 
-* iOS developers should read the [Dronecode-SDK-Swift](http://dronecode-sdk-swift.s3.eu-central-1.amazonaws.com/docs/master/index.html) reference.
-
-  > **Tip** The MAVSDK-Swift is in alpha development. 
-    We plan to make our first official (beta) release in the coming weeks.
-
+* Python 3 developers install and use [MAVSDK-Python](https://github.com/mavlink/MAVSDK-Python#mavsdk-python) from PyPi (`pip3 install mavsdk`). 
+  There is no further setup, so you can then immediately run the [examples](https://github.com/mavlink/MAVSDK-Python/tree/master/examples) in the normal way. 
+  The drone API is essentially the same as for the [C++ API](api_reference/README.md).
+* iOS developers should start from the [Dronecode-SDK-Swift](http://dronecode-sdk-swift.s3.eu-central-1.amazonaws.com/docs/master/index.html) reference.
 * C++ Developers should start at the [C++ Library](cpp/README.md).
-
-* Developers who want to contribute to the API will need to build the C++ library (and other programming language wrappers) from source.
+  For recent releases *Ubuntu* and *Fedora* users can install the SDK from _*.deb_ or _*.rpm_ packages in the [Github release](https://github.com/mavlink/MAVSDK/releases) page.
+* Developers who want to *contribute* to the API will need to build the C++ library (and other programming language wrappers) from source.
   For more information see the [contributing section](#contributing) below.
  
 

--- a/en/README.md
+++ b/en/README.md
@@ -1,5 +1,4 @@
-<div style="float:right; padding:10px; margin-right:20px;"><a href="https://www.dronecode.org/sdk/"><img src="../assets/site/sdk_logo_full.png" title="MAVSDK Logo" width="400px"/></a></div>
-
+<img src="../assets/site/sdk_logo_full.png" title="MAVSDK Logo" width="400px"/>
 # MAVSDK ({{ book.github_branch }})
 
 [![Slack](https://px4-slack.herokuapp.com/badge.svg)](http://slack.px4.io)&nbsp;[![Discuss](https://img.shields.io/badge/discuss-MAVSDK-ff69b4.svg)](https://discuss.px4.io/c/sdk) [![travis-ci build status](https://travis-ci.org/mavlink/MAVSDK.svg?branch=develop)](https://travis-ci.org/mavlink/MAVSDK)

--- a/en/README.md
+++ b/en/README.md
@@ -8,7 +8,7 @@
 
 The *MAVSDK* is a [MAVLink](https://mavlink.io/en/) Library with APIs for [C++](cpp/README.md), [iOS](http://dronecode-sdk-swift.s3.eu-central-1.amazonaws.com/docs/master/index.html), Python and Android.
 
-> **Tip** The SDK is the best way to integrate with a flight stack over MAVLink! 
+> **Tip** The SDK is the best way to integrate with a flight stack over MAVLink!
   It is supported by [Dronecode](https://www.dronecode.org/), ensuring that it is robust, well tested, and maintained.
 
 The library provides a simple API for managing one or more vehicles, providing programmatic access to vehicle information and telemetry, and control over missions, movement and other operations.
@@ -22,11 +22,17 @@ These (primarily) use [gRPC](https://grpc.io/) and [Reactive Extensions](http://
 
 ## Project Status
 
-The MAVSDK is a robust and well-tested library that is already in use in production environments.
-- The core C++ API has been created and is (largely) stable.
-- iOS development is supported using the [Dronecode-SDK-Swift](http://dronecode-sdk-swift.s3.eu-central-1.amazonaws.com/docs/master/index.html) library.
-- Python is supported using [MAVSDK-Python](https://github.com/mavlink/MAVSDK-Python#mavsdk-python)
-- Other cross-platform wrappers are actively being developed, and should be released soon.
+The MAVSDK is a robust and well-tested library that is already being used in production environments.
+
+> **Note** Future compatibility is not guaranteed (the API is not "stable").
+
+The current status is:
+- C++ core library (2016). Used in production.
+- MAVSDK-Swift (2018): Used in production.
+- MAVSDK-Python (2019): First PyPi release 2019.
+- MAVSDK-Java (2019): Prototype.
+- MAVSDK-JavaScript (2019). Proof of concept.
+- Other cross-platform wrappers are actively being developed.
 
 
 ## Getting Started
@@ -36,14 +42,11 @@ The MAVSDK is a robust and well-tested library that is already in use in product
   The drone API is essentially the same as for the [C++ API](api_reference/README.md).
 * iOS developers should start from the [Dronecode-SDK-Swift](http://dronecode-sdk-swift.s3.eu-central-1.amazonaws.com/docs/master/index.html) reference.
 * C++ Developers should start at the [C++ Library](cpp/README.md).
-  For recent releases *Ubuntu* and *Fedora* users can install the SDK from _*.deb_ or _*.rpm_ packages in the [Github release](https://github.com/mavlink/MAVSDK/releases) page.
-* Developers who want to *contribute* to the API will need to build the C++ library (and other programming language wrappers) from source.
-  For more information see the [contributing section](#contributing) below.
  
 
 ## Getting Help
 
-This guide contains information and examples showing how to use the SDK. 
+This guide contains information and examples showing how to use the SDK.
 If you have specific questions that are not answered by the documentation, these can be raised on:
 
 * [Discuss board](https://discuss.px4.io/c/mavsdk)

--- a/en/contributing/build.md
+++ b/en/contributing/build.md
@@ -6,8 +6,7 @@ It also shows how to build the SDK with extensions and build the API Reference d
 
 ## Build the C++ Library {#build_sdk_cpp}
 
-This section explains how to build the SDK C++ library from source,
-along with its unit and integration tests.
+This section explains how to build the SDK C++ library from source, along with its unit and integration tests.
 Build artifacts are created in the **build** subdirectory.
 
 ### macOS {#build_cpp_mac_os}

--- a/en/cpp/README.md
+++ b/en/cpp/README.md
@@ -1,5 +1,4 @@
-<div style="float:right; padding:10px; margin-right:20px;"><a href="https://www.dronecode.org/sdk/"><img src="../../assets/site/sdk_logo_full.png" title="MAVSDK Logo" width="400px"/></a></div>
-# MAVSDK Core C++ Library
+# MAVSDK Core C++ Library <div style="float:right; padding:10px; margin-right:20px;"><img src="../../assets/site/sdk_logo_full.png" title="MAVSDK Logo" width="180px"/></div>
 [![Slack](https://px4-slack.herokuapp.com/badge.svg)](http://slack.px4.io)&nbsp;[![Discuss](https://img.shields.io/badge/discuss-MAVSDK-ff69b4.svg)](https://discuss.px4.io/c/sdk) [![travis-ci build status](https://travis-ci.org/mavlink/MAVSDK.svg?branch=develop)](https://travis-ci.org/mavlink/MAVSDK)
 [![Build status](https://ci.appveyor.com/api/projects/status/1ntjvooywpxmoir8/branch/develop?svg=true)](https://ci.appveyor.com/project/Dronecode/dronecore/branch/develop)
 [![Coverage Status](https://coveralls.io/repos/github/mavlink/MAVSDK/badge.svg?branch=develop)](https://coveralls.io/github/mavlink/MAVSDK?branch=develop)
@@ -62,5 +61,5 @@ They should only be used where features are missing from the main APIs above.
 
 The [Contributing](../contributing/README.md) section contains everything you need to contribute to the C++ API, including topics about building the SDK from source code, running our integration and unit tests, and all other aspects of core development. 
 
-> **Tip** Developers who want to create plugins and contribute to the API will need to [build the library](../contributing/build.md) (and other programming language wrappers) from source. 
+> **Tip** Developers who want to create plugins and contribute to the API will need to [build the library ](../contributing/build.md) (and other programming language wrappers) from source. 
 

--- a/en/cpp/README.md
+++ b/en/cpp/README.md
@@ -21,14 +21,12 @@ Note however that the API is still being evolved and the project does not provid
 
 ## Getting Started
 
-At time of writing all users will need to [build the library](../contributing/build.md) in order to use it. 
-In the near future we'll have binary releases for the wrapper APIs.
+*Ubuntu* and *Fedora* users can install the SDK from _*.deb_ or _*.rpm_ packages in the [Github release](https://github.com/mavlink/MAVSDK/releases) page.
 
-This [Guide](../guide/README.md) explains how to write MAVSDK apps using C++. 
+> **Note** Windows and macOS users will need to [build the library from source](../contributing/build.md) in order to use it.
+
+This [Guide](../guide/README.md) explains how to write MAVSDK apps using C++.
 A simple complete example can be found in [Takeoff and Land](../examples/takeoff_and_land.md).
-
-Developers who want to create plugins and contribute to the API will need to build the C++ library (and other programming language wrappers) from source. 
-For more information see the [contributing section](#contributing) below.
 
 
 ## API Overview
@@ -63,4 +61,6 @@ They should only be used where features are missing from the main APIs above.
 ## Contributing/Extending
 
 The [Contributing](../contributing/README.md) section contains everything you need to contribute to the C++ API, including topics about building the SDK from source code, running our integration and unit tests, and all other aspects of core development. 
+
+> **Tip** Developers who want to create plugins and contribute to the API will need to [build the library](../contributing/build.md) (and other programming language wrappers) from source. 
 

--- a/en/examples/README.md
+++ b/en/examples/README.md
@@ -54,7 +54,20 @@ See [QGroundControl > Download and Install](https://docs.qgroundcontrol.com/en/g
 To build the examples follow the instructions below, replacing *takeoff_and_land* with the name of the specific example.
 Any exceptions will be covered in the page for the associated example(s).
 
+
 #### Linux
+
+Ubuntu or Fedora users should install the MAVSDK C++ _*.deb_ or _*.rpm_ packages from the [Github release page](https://github.com/mavlink/MAVSDK/releases) in the normal way (or [build and install the SDK C++ Library](../contributing/build.md#sdk_system_wide_install) system-wide).
+
+Then build the example:
+```sh
+cd example/takeoff_land/
+mkdir build && cd build
+cmake ..
+make
+```
+
+#### macOS
 
 First [Build and install the SDK C++ Library](../contributing/build.md) system-wide using the command below:
 ```sh
@@ -70,6 +83,7 @@ mkdir build && cd build
 cmake ..
 make
 ```
+
 
 #### Windows
 

--- a/en/getting_started/README.md
+++ b/en/getting_started/README.md
@@ -1,6 +1,6 @@
-<div style="float:right; padding:10px; margin-right:20px;"><a href="https://www.dronecode.org/sdk/"><img src="../../assets/site/sdk_logo_full.png" title="MAVSDK Logo" width="400px"/></a></div>
+# Getting Started <div style="float:right; padding:10px; margin-right:20px;"><img src="../../assets/site/sdk_logo_full.png" title="MAVSDK Logo" width="180px"/></div>
 
-# Getting Started
+<!-- NOTE, currently not built into final docset -->
 
 This topic explains how to set up a development environment and write a minimal example for all our supported programming languages/platforms.
 


### PR DESCRIPTION
- Remove flight-stack specifics.
- Add python link to getting started. Clarify that it had/does everything.
- General changes to make it clear that C library doesn't need to be built on ubuntu/fedora
