### PR TITLE
Update build.md

### DIFF
--- a/en/contributing/build.md
+++ b/en/contributing/build.md
@@ -152,9 +152,9 @@ cmake --build build/default --target install
 ```
 
 > **Tip** If you already have run cmake without setting `CMAKE_INSTALL_PREFIX`, you may need to clean the build first:
-     ```sh
-     rm -rf build/default
-     ```
+```sh
+rm -rf build/default
+```
 
 ## Build for Android {#build_cpp_android}
 


### PR DESCRIPTION
Formatting error for instructions under "Local install" section, unindenting the markup seems to have fixed it.