### PR TITLE
Fix wrong links in follow_me and examples documentation

### DIFF
--- a/en/examples/README.md
+++ b/en/examples/README.md
@@ -11,7 +11,7 @@ Example | Description
 [Fly Mission](../examples/fly_mission.md) | Shows how to create, upload, and run missions.
 [Fly Multiple Drones](https://github.com/mavlink/MAVSDK/tree/{{ book.github_branch }}/examples/fly_multiple_drones) | Example to connect multiple vehicles and make them follow their own separate plan file. Also saves the telemetry information to CSV files.
 [Fly QGC Plan Mission](../examples/fly_mission_qgc_plan.md) | Fly a mission imported from a *QGroundControl* mission plan.
-[Follow Me Mode](../examples/offboard_velocity.md) | Demonstrates how to put vehicle in [Follow Me Mode](../guide/follow_me.md) and set the current target position and relative position of the drone.
+[Follow Me Mode](../examples/follow_me.md) | Demonstrates how to put vehicle in [Follow Me Mode](../guide/follow_me.md) and set the current target position and relative position of the drone.
 [GeoFence Inclusion](https://github.com/mavlink/MAVSDK/tree/{{ book.github_branch }}/examples/geofence_inclusion) | Demonstrates how to define and upload a simple polygonal inclusion GeoFence.
 [MAVLink FTP Client](https://github.com/mavlink/MAVSDK/tree/{{ book.github_branch }}/examples/mavlink_ftp_client) | Demonstrates how to create/use a [MAVLink FTP client](https://mavlink.io/en/services/ftp.html).
 [MAVLink FTP Server](https://github.com/mavlink/MAVSDK/tree/{{ book.github_branch }}/examples/mavlink_ftp_server) | Demonstrates how to start/set up a [MAVLink FTP server](https://mavlink.io/en/services/ftp.html).

--- a/en/examples/follow_me.md
+++ b/en/examples/follow_me.md
@@ -110,7 +110,7 @@ The operation of the "SDK-specific" part of this code is discussed in the guide:
 
 ## Source code {#source_code}
 
-> **Tip** The full source code for the example [can be found on Github here](https://github.com/mavlink/MAVSDK/tree/{{ book.github_branch }}/examples/fly_mission).
+> **Tip** The full source code for the example [can be found on Github here](https://github.com/mavlink/MAVSDK/tree/{{ book.github_branch }}/examples/follow_me).
 
 
 [CMakeLists.txt](https://github.com/mavlink/MAVSDK/blob/{{ book.github_branch }}/examples/follow_me/CMakeLists.txt)


### PR DESCRIPTION
## Changes
1. A link on example page's follow-me category, it's link previously went to offboard doc.
2. Link on Follow-me's documentation linked towards fly_mission doc.

## Thank you note
Fixed two links! Great Doc, helped a lot!

## Quick question
Just curious, some links inside the .md files use notations like `https://github.com/mavlink/MAVSDK/**blob**/{{ book.github_branch }}/examples/follow_me/` but others use `https://github.com/mavlink/MAVSDK/**tree**/{{ book.github_branch }}/examples/fly_multiple_drones`. Are there differences between 'blob' and a 'tree'?