### PR TITLE
Action::Result::SUCCESS > Success

### DIFF
--- a/en/examples/fly_mission.md
+++ b/en/examples/fly_mission.md
@@ -402,7 +402,7 @@ int main(int argc, char **argv)
         // We are done, and can do RTL to go home.
         std::cout << "Commanding RTL..." << std::endl;
         const Action::Result result = action->return_to_launch();
-        if (result != Action::Result::SUCCESS) {
+        if (result != Action::Result::Success) {
             std::cout << "Failed to command RTL (" << Action::result_str(result) << ")"
                       << std::endl;
         } else {
@@ -441,7 +441,7 @@ std::shared_ptr<MissionItem> make_mission_item(double latitude_deg,
 
 inline void handle_action_err_exit(Action::Result result, const std::string &message)
 {
-    if (result != Action::Result::SUCCESS) {
+    if (result != Action::Result::Success) {
         std::cerr << ERROR_CONSOLE_TEXT << message << Action::result_str(result)
                   << NORMAL_CONSOLE_TEXT << std::endl;
         exit(EXIT_FAILURE);

--- a/en/examples/fly_mission_qgc_plan.md
+++ b/en/examples/fly_mission_qgc_plan.md
@@ -311,7 +311,7 @@ int main(int argc, char **argv)
         // Mission complete. Command RTL to go home.
         std::cout << "Commanding RTL..." << std::endl;
         const Action::Result result = action->return_to_launch();
-        if (result != Action::Result::SUCCESS) {
+        if (result != Action::Result::Success) {
             std::cout << "Failed to command RTL (" << Action::result_str(result) << ")"
                       << std::endl;
         } else {
@@ -324,7 +324,7 @@ int main(int argc, char **argv)
 
 inline void handle_action_err_exit(Action::Result result, const std::string &message)
 {
-    if (result != Action::Result::SUCCESS) {
+    if (result != Action::Result::Success) {
         std::cerr << ERROR_CONSOLE_TEXT << message << Action::result_str(result)
                   << NORMAL_CONSOLE_TEXT << std::endl;
         exit(EXIT_FAILURE);

--- a/en/examples/follow_me.md
+++ b/en/examples/follow_me.md
@@ -297,7 +297,7 @@ int main(int argc, char **argv)
 // Handles Action's result
 inline void action_error_exit(Action::Result result, const std::string &message)
 {
-    if (result != Action::Result::SUCCESS) {
+    if (result != Action::Result::Success) {
         std::cerr << ERROR_CONSOLE_TEXT << message << Action::result_str(result)
                   << NORMAL_CONSOLE_TEXT << std::endl;
         exit(EXIT_FAILURE);

--- a/en/examples/offboard_velocity.md
+++ b/en/examples/offboard_velocity.md
@@ -128,7 +128,7 @@ using std::chrono::seconds;
 // Handles Action's result
 inline void action_error_exit(Action::Result result, const std::string &message)
 {
-    if (result != Action::Result::SUCCESS) {
+    if (result != Action::Result::Success) {
         std::cerr << ERROR_CONSOLE_TEXT << message << Action::result_str(result)
                   << NORMAL_CONSOLE_TEXT << std::endl;
         exit(EXIT_FAILURE);

--- a/en/examples/takeoff_and_land.md
+++ b/en/examples/takeoff_and_land.md
@@ -201,7 +201,7 @@ int main(int argc, char **argv)
     std::cout << "Arming..." << std::endl;
     const Action::Result arm_result = action->arm();
 
-    if (arm_result != Action::Result::SUCCESS) {
+    if (arm_result != Action::Result::Success) {
         std::cout << ERROR_CONSOLE_TEXT << "Arming failed:" << Action::result_str(arm_result)
                   << NORMAL_CONSOLE_TEXT << std::endl;
         return 1;
@@ -210,7 +210,7 @@ int main(int argc, char **argv)
     // Take off
     std::cout << "Taking off..." << std::endl;
     const Action::Result takeoff_result = action->takeoff();
-    if (takeoff_result != Action::Result::SUCCESS) {
+    if (takeoff_result != Action::Result::Success) {
         std::cout << ERROR_CONSOLE_TEXT << "Takeoff failed:" << Action::result_str(takeoff_result)
                   << NORMAL_CONSOLE_TEXT << std::endl;
         return 1;
@@ -221,7 +221,7 @@ int main(int argc, char **argv)
 
     std::cout << "Landing..." << std::endl;
     const Action::Result land_result = action->land();
-    if (land_result != Action::Result::SUCCESS) {
+    if (land_result != Action::Result::Success) {
         std::cout << ERROR_CONSOLE_TEXT << "Land failed:" << Action::result_str(land_result)
                   << NORMAL_CONSOLE_TEXT << std::endl;
         return 1;

--- a/en/examples/transition_vtol_fixed_wing.md
+++ b/en/examples/transition_vtol_fixed_wing.md
@@ -180,7 +180,7 @@ int main(int argc, char **argv)
     std::cout << "Arming." << std::endl;
     const Action::Result arm_result = action->arm();
 
-    if (arm_result != Action::Result::SUCCESS) {
+    if (arm_result != Action::Result::Success) {
         std::cout << ERROR_CONSOLE_TEXT << "Arming failed: " << Action::result_str(arm_result)
                   << NORMAL_CONSOLE_TEXT << std::endl;
         return 1;
@@ -189,7 +189,7 @@ int main(int argc, char **argv)
     // Take off
     std::cout << "Taking off." << std::endl;
     const Action::Result takeoff_result = action->takeoff();
-    if (takeoff_result != Action::Result::SUCCESS) {
+    if (takeoff_result != Action::Result::Success) {
         std::cout << ERROR_CONSOLE_TEXT << "Takeoff failed:n" << Action::result_str(takeoff_result)
                   << NORMAL_CONSOLE_TEXT << std::endl;
         return 1;
@@ -201,7 +201,7 @@ int main(int argc, char **argv)
     std::cout << "Transition to fixedwing." << std::endl;
     const Action::Result fw_result = action->transition_to_fixedwing();
 
-    if (fw_result != Action::Result::SUCCESS) {
+    if (fw_result != Action::Result::Success) {
         std::cout << ERROR_CONSOLE_TEXT
                   << "Transition to fixed wing failed: " << Action::result_str(fw_result)
                   << NORMAL_CONSOLE_TEXT << std::endl;
@@ -215,7 +215,7 @@ int main(int argc, char **argv)
     std::cout << "Sending it to location." << std::endl;
     // We pass latitude and longitude but leave altitude and yaw unset by passing NAN.
     const Action::Result goto_result = action->goto_location(47.3633001, 8.5428515, NAN, NAN);
-    if (goto_result != Action::Result::SUCCESS) {
+    if (goto_result != Action::Result::Success) {
         std::cout << ERROR_CONSOLE_TEXT
                   << "Goto command failed: " << Action::result_str(goto_result)
                   << NORMAL_CONSOLE_TEXT << std::endl;
@@ -228,7 +228,7 @@ int main(int argc, char **argv)
     // Let's stop before reaching the goto point and go back to hover.
     std::cout << "Transition back to multicopter..." << std::endl;
     const Action::Result mc_result = action->transition_to_multicopter();
-    if (mc_result != Action::Result::SUCCESS) {
+    if (mc_result != Action::Result::Success) {
         std::cout << ERROR_CONSOLE_TEXT
                   << "Transition to multi copter failed: " << Action::result_str(mc_result)
                   << NORMAL_CONSOLE_TEXT << std::endl;
@@ -241,7 +241,7 @@ int main(int argc, char **argv)
     // Now just land here.
     std::cout << "Landing..." << std::endl;
     const Action::Result land_result = action->land();
-    if (land_result != Action::Result::SUCCESS) {
+    if (land_result != Action::Result::Success) {
         std::cout << ERROR_CONSOLE_TEXT << "Land failed: " << Action::result_str(land_result)
                   << NORMAL_CONSOLE_TEXT << std::endl;
         return 1;

--- a/en/guide/taking_off_landing.md
+++ b/en/guide/taking_off_landing.md
@@ -128,7 +128,7 @@ Once the vehicle is ready, use the following synchronous code to arm:
 std::cout << "Arming..." << std::endl;
 const Action::Result arm_result = action->arm();
 
-if (arm_result != Action::Result::SUCCESS) {
+if (arm_result != Action::Result::Success) {
     std::cout << "Arming failed:" 
       << Action::result_str(arm_result) 
       <<  std::endl;
@@ -136,7 +136,7 @@ if (arm_result != Action::Result::SUCCESS) {
 }
 ```
 
-> **Tip** If the `arm()` method returns `Action::Result::SUCCESS` then the vehicle is armed and can proceed to takeoff. This can be confirmed using [Telemetry::armed()](../api_reference/classmavsdk_1_1_telemetry.md#classmavsdk_1_1_telemetry_1a6620142adc47f069262e5bf69dbb3876).
+> **Tip** If the `arm()` method returns `Action::Result::Success` then the vehicle is armed and can proceed to takeoff. This can be confirmed using [Telemetry::armed()](../api_reference/classmavsdk_1_1_telemetry.md#classmavsdk_1_1_telemetry_1a6620142adc47f069262e5bf69dbb3876).
 
 
 ### Get/Set Takeoff Altitude
@@ -156,7 +156,7 @@ The code below uses the synchronous `takeoff()` method, and fails if the vehicle
 // Command Take off
 std::cout << "Taking off..." << std::endl;
 const Action::Result takeoff_result = action->takeoff();
-if (takeoff_result != Action::Result::SUCCESS) {
+if (takeoff_result != Action::Result::Success) {
     std::cout << "Takeoff failed:" << Action::result_str(
         takeoff_result) << std::endl;
     return 1;
@@ -191,7 +191,7 @@ The code below shows how to use the land action.
 
 ```cpp
 const Action::Result land_result = action->land();
-if (land_result != Action::Result::SUCCESS) {
+if (land_result != Action::Result::Success) {
     //Land failed, so exit (in reality might try a return to land or kill.)
     return 1;
 }
@@ -217,7 +217,7 @@ The code below shows how to use the synchronous method:
 
 ```cpp
 const Action::Result rtl_result = telemetry->return_to_launch();
-if (rtl_result != Action::Result::SUCCESS) {
+if (rtl_result != Action::Result::Success) {
     //RTL failed, so exit (in reality might send kill command.)
     return 1;
 }
@@ -263,7 +263,7 @@ and to print the result of the call (the other synchronous method is used in the
 ```cpp
 const Action::Result fw_result = action->transition_to_fixedwing();
 
-if (fw_result != Action::Result::SUCCESS) {
+if (fw_result != Action::Result::Success) {
     std::cout << "Transition to fixed wing failed: " 
         << Action::result_str(fw_result) << std::endl;
 }


### PR DESCRIPTION
Updates examples to use the new form of success (i.e. match to https://github.com/mavlink/MAVSDK/pull/1024)

Note this is just a search/replace. I didn't make sure the examples are otherwise up to date, so possibly there could have been other missed changes.