### PR TITLE
Add API changes notes

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -7,6 +7,7 @@
 * [Python](https://github.com/mavlink/MAVSDK-Python#mavsdk-python)
 * [C++ (MAVSDK Core)](cpp/README.md)
   * [C++ QuickStart](cpp/quickstart.md)
+  * [C++ API changes](cpp/api_changes.md)
   * [Guide](guide/README.md)
     * [Usage/Paradigms](guide/general_usage.md)
     * [Connecting to Systems (Vehicles)](guide/connections.md)

--- a/en/cpp/README.md
+++ b/en/cpp/README.md
@@ -27,7 +27,7 @@ A simple complete example can be found in [Takeoff and Land](../examples/takeoff
 
 ## Updating / API changes
 
-Information about how the API changes from one version to the next: [API cchanges](api_changes.md).
+Information about API changes between versions: [API changes](api_changes.md).
 
 ## API Overview
 

--- a/en/cpp/README.md
+++ b/en/cpp/README.md
@@ -25,6 +25,9 @@ Note however that the API is still being evolved and the project does not provid
 This [Guide](../guide/README.md) explains how to write MAVSDK apps using C++.
 A simple complete example can be found in [Takeoff and Land](../examples/takeoff_and_land.md).
 
+## Updating / API changes
+
+Information about how the API changes from one version to the next: [API cchanges](api_changes.md).
 
 ## API Overview
 
@@ -57,7 +60,7 @@ They should only be used where features are missing from the main APIs above.
 
 ## Contributing/Extending
 
-The [Contributing](../contributing/README.md) section contains everything you need to contribute to the C++ API, including topics about building the SDK from source code, running our integration and unit tests, and all other aspects of core development. 
+The [Contributing](../contributing/README.md) section contains everything you need to contribute to the C++ API, including topics about building the SDK from source code, running our integration and unit tests, and all other aspects of core development.
 
-> **Tip** Developers who want to create plugins and contribute to the API will need to [build the library ](../contributing/build.md) (and other programming language wrappers) from source. 
+> **Tip** Developers who want to create plugins and contribute to the API will need to [build the library ](../contributing/build.md) (and other programming language wrappers) from source.
 

--- a/en/cpp/api_changes.md
+++ b/en/cpp/api_changes.md
@@ -111,7 +111,7 @@ The separate class `MissionItem` is now just a POD struct inside `Mission`, so `
 
 #### Methods
 
-- Progress is now Mission Progress:
+- `Progress` is now `MissionProgress`:
 
   Old:
   ```cpp

--- a/en/cpp/api_changes.md
+++ b/en/cpp/api_changes.md
@@ -116,6 +116,10 @@ The separate class `MissionItem` is now just a POD struct inside `Mission`, so `
   std::pair<Result, bool> is_mission_finished();
   ```
 
+### Calibration
+
+The results `IN_PROGRESS` and `INSTRUCTION` disappear in favor of `Next`. Now, `Success` means that the function finished successfully, `Next` represents a new element of the stream and all the other results mean that the function finished with an error (described by the result).
+
 ### Geofence
 
 #### Methods

--- a/en/cpp/api_changes.md
+++ b/en/cpp/api_changes.md
@@ -17,7 +17,7 @@ Individual parts of the number are iterated when the:
 
 This means that breaking changes to the API result in a bump of the major version number (e.g. 1.4.3 to 2.0.0).
 
-> **Note** At time of writing, breaking/incompatible changes *are not* resulting in the major version number being increased! 
+> **Note** At time of writing, breaking/incompatible changes *are not* resulting in the major version number being increased!
   We plan to release version 1.0.0 in the near future, after which the above strategy will be adopted (i.e. currently breaking changes can occur in both minor and patch releases).
 
 
@@ -34,11 +34,11 @@ There are several changes in this release (from v0.24.0) because the C++ plugins
 - Enum naming is now `CamelCase` instead of `ALL_UPPERCASE`:
 
   `Action::RESULT` -> `Action::Result`
-  
+
   `Telemetry::FLIGHT_MODE` -> `Telemetry::FlightMode`
 
 - Printing of enums is easier:
-  
+
   Old:
   ```
   std::cout << flight_mode_str(flight_mode);
@@ -94,7 +94,7 @@ The separate class `MissionItem` is now just a POD struct inside `Mission`, so `
   Old:
   ```cpp
   typedef std::function<void(Result, std::vector<MissionItem>)> mission_items_and_result_callback_t;
-  
+
   download_mission_async(mission_items_and_result_callback_t, callback)
   ```
   New:
@@ -115,3 +115,20 @@ The separate class `MissionItem` is now just a POD struct inside `Mission`, so `
   ```cpp
   std::pair<Result, bool> is_mission_finished();
   ```
+
+### Geofence
+
+#### Methods
+
+Old:
+```
+send_geofence_async(...);
+```
+New:
+```
+upload_geofence_async(...);
+```
+Or:
+```
+upload_geofence(...);
+```

--- a/en/cpp/api_changes.md
+++ b/en/cpp/api_changes.md
@@ -21,11 +21,9 @@ This means that breaking changes to the API result in a bump of the major versio
   We plan to release version 1.0.0 in the near future, after which the above strategy will be adopted (i.e. currently breaking changes can occur in both minor and patch releases).
 
 
-## Specific Transition Notices
+## v0.25.0
 
-### v0.24.0 to v0.25.0
-
-There are several changes in this release because the C++ plugins are now partially auto-generated from the proto files. While this causes some painful changes, it has several advantages:
+There are several changes in this release (from v0.24.0) because the C++ plugins are now partially auto-generated from the proto files. While this causes some painful changes, it has several advantages:
 - Better consistency between C++ and other languages for naming/docs/functionality.
 - Missing features for language wrappers such as Python.
 

--- a/en/cpp/api_changes.md
+++ b/en/cpp/api_changes.md
@@ -43,7 +43,7 @@ The notes below try to give an overview over the changes as well as give some ba
 
 > **Note** For enums, there is also a [script](https://github.com/mavlink/MAVSDK/blob/v0.25.0/tools/rename-enums-to-camelcase.sh) that you can run to fix them in one batch.
 
-  The reasoning behind this change is to avoid clashse with macros. For instance we had conflicts with `ERROR` or `SOCKET_ERROR` on Windows ([issue](https://github.com/mavlink/MAVSDK/issues/953)).
+  The reasoning behind this change is to avoid clashes with macros. For instance we had conflicts with `ERROR` or `SOCKET_ERROR` on Windows ([issue](https://github.com/mavlink/MAVSDK/issues/953)).
 
 - Printing of enums is easier:
 

--- a/en/cpp/api_changes.md
+++ b/en/cpp/api_changes.md
@@ -1,23 +1,27 @@
-# API changes
+# API Changes
 
-## General comment
+This page tracks changes between versions.
 
-We would like to keep the API of MAVSDK as stable as possible, however, we don't want to stand still and also improve over time. Therefore, sometimes breaking changes are required.
+It covers both breaking (incompatible) and non-breaking changes.
 
-### SemVer
+## Semantic Versioning
 
-We try to follow the [semver/Semantic Versioning](https://semver.org/) conventions as much as possible.
+MAVSDK follows [semver/Semantic Versioning](https://semver.org/) conventions where as possible.
 
-High level this means that the version number is **major.minor.patch**.
+The version number has the format: **major.minor.patch**.
+Individual parts of the number are iterated when the:
 
-- **major**: Bumping when the API is changed, or functionality is removed.
-- **minor**: Bumping when the API is extended, functionality is added.
-- **patch**: Bumping when the API is not changed, functionality is not changed, but a bug is fixed.
+- **major**: API is changed, or functionality is removed.
+- **minor**: API is extended, functionality is added.
+- **patch**: API is not changed, functionality is not changed, but a bug is fixed.
 
-This means that breaking the API goes with a bump of the major version number (e.g. 1.4.3 to 2.0.0), however, we ignore that until version 1.0.0, so we allow to break the API of 0.y.z.
+This means that breaking changes to the API result in a bump of the major version number (e.g. 1.4.3 to 2.0.0).
+
+> **Note** At time of writing, breaking/incompatible changes *are not* resulting in the major version number being increased! 
+  We plan to release version 1.0.0 in the near future, after which the above strategy will be adopted (i.e. currently breaking changes can occur in both minor and patch releases).
 
 
-## Specific transition notices
+## Specific Transition Notices
 
 ### v0.24.0 to v0.25.0
 
@@ -34,8 +38,9 @@ Enum naming is now `CamelCase` instead of `ALL_UPPERCASE`:
 `Action::RESULT` -> `Action::Result`
 `Telemetry::FLIGHT_MODE` -> `Telemetry::FlightMode`
 
-Printing of enums is easier,
-old:
+Printing of enums is easier:
+
+Old:
 ```
 std::cout << flight_mode_str(flight_mode);
 ```
@@ -57,8 +62,9 @@ The separate class `MissionItem` is now just a POD struct inside `Mission`, so `
 
 #### Methods
 
-To get the mission progress, the method is now named in the same way as subscriptions in the telemetry plugin,
-old:
+To get the mission progress, the method is now named in the same way as subscriptions in the telemetry plugin:
+
+Old:
 ```
 subscribe_mission_progress(subscribe_mission_callback_t callback);
 ```
@@ -100,10 +106,11 @@ typedef std::function<void(Result, MissionPlan)> download_mission_callback_t;
 void download_mission_async(const Mission::download_mission_callback_t& callback);
 ```
 
-> **Tip** There are now also sync methods to upload and download a mission `upload_mission` and `download_mission`.
+> **Tip** There are now also sync methods to upload and download a mission: `upload_mission` and `download_mission`.
 
-Some methods now return a `std::pair<Result, bool>` instead of just a `bool` to cover the case where a request fails, e.g.
-old:
+Some methods now return a `std::pair<Result, bool>` instead of just a `bool` to cover the case where a request fails.
+
+Old:
 ```
 bool mission_finished();
 ```

--- a/en/cpp/api_changes.md
+++ b/en/cpp/api_changes.md
@@ -103,6 +103,34 @@ This change was decided in order to move with the [modern C++ recommendation](ht
 
 - Methods returning a bool are now mostly prefixed with `is_`. E.g. `is_health_ok` instead of `health_ok`.
 
+
+### Telemetry
+
+#### Types
+
+Some of the types have been renamed for consistency:
+
+```
+AccelerationNED -> AccelerationFrd
+AngularVelocityNED -> AngularVelocityFrd
+IMUReadingNED -> Imu
+MagneticFieldNED -> MagneticFieldFrd
+GroundSpeedNED -> VelocityNed
+SpeedBody -> VelocityBody
+```
+
+The changes were mostly for consistency, or correctness.
+
+#### Methods
+
+In the same way, some of the methods changed:
+
+```
+set_rate_ground_speed -> set_rate_velocity_ned
+ground_speed_async -> subscribe_velocity_ned
+```
+
+
 ### Mission
 
 #### Classes
@@ -214,3 +242,14 @@ Geofence::Point point;
 ```
 
 Also, we no longer pass polygons with `std::shared_ptr<Geofence::Polygon>` but by value `Geofence::Polygon`.
+
+### Offboard
+
+####Types
+
+Matching with the rest, acronyms are not all capitalized anymore, mostly because that's easier to deal with in auto-generation:
+
+```
+PositionNEDYaw -> PositionNedYaw
+VelocityNED -> VelocityNedYaw
+```

--- a/en/cpp/api_changes.md
+++ b/en/cpp/api_changes.md
@@ -58,6 +58,15 @@ The notes below try to give an overview over the changes as well as give some ba
 
   With auto-generation it is quite easy to make sure everything is printable using streams and we can drop the custom `_str` functions.
 
+  To get a `std::string` from `operator<<` you can use:
+  ```
+  #include <sstream>
+
+  std::stringstream ss;
+  ss << flight_mode;
+  std::string str = ss.str();
+  ```
+
 
 #### Callback types
 

--- a/en/cpp/api_changes.md
+++ b/en/cpp/api_changes.md
@@ -25,7 +25,7 @@ This means that breaking changes to the API result in a bump of the major versio
 
 There are several changes in this release (from v0.24.0) because the C++ plugins are now partially auto-generated from the proto files. While this causes some painful changes, it has several advantages:
 - Better consistency between C++ and other languages for naming/docs/functionality.
-- Missing features for language wrappers such as Python.
+- Automatically propagate features to language wrappers such as Python.
 
 > **Note** It's also worth looking at the integration tests and examples between the versions to see how things changed: [GitHub diff view](https://github.com/mavlink/MAVSDK/compare/v0.24.0...v0.25.0).
 

--- a/en/cpp/api_changes.md
+++ b/en/cpp/api_changes.md
@@ -1,0 +1,114 @@
+# API changes
+
+## General comment
+
+We would like to keep the API of MAVSDK as stable as possible, however, we don't want to stand still and also improve over time. Therefore, sometimes breaking changes are required.
+
+### SemVer
+
+We try to follow the [semver/Semantic Versioning](https://semver.org/) conventions as much as possible.
+
+High level this means that the version number is **major.minor.patch**.
+
+- **major**: Bumping when the API is changed, or functionality is removed.
+- **minor**: Bumping when the API is extended, functionality is added.
+- **patch**: Bumping when the API is not changed, functionality is not changed, but a bug is fixed.
+
+This means that breaking the API goes with a bump of the major version number (e.g. 1.4.3 to 2.0.0), however, we ignore that until version 1.0.0, so we allow to break the API of 0.y.z.
+
+
+## Specific transition notices
+
+### v0.24.0 to v0.25.0
+
+There are several changes in this release because the C++ plugins are now partially auto-generated from the proto files. While this causes some painful changes, it has several advantages:
+- Better consistency between C++ and other languages for naming/docs/functionality.
+- Missing features for language wrappers such as Python.
+
+### General
+
+#### Enums
+
+Enum naming is now `CamelCase` instead of `ALL_UPPERCASE`:
+
+`Action::RESULT` -> `Action::Result`
+`Telemetry::FLIGHT_MODE` -> `Telemetry::FlightMode`
+
+Printing of enums is easier,
+old:
+```
+std::cout << flight_mode_str(flight_mode);
+```
+
+New:
+```
+std::cout << flight_mode;
+```
+
+#### Methods
+
+Methods returning a bool are now mostly prefixed with `is_`. E.g. `is_health_ok` instead of `health_ok`.
+
+### Mission
+
+#### Classes
+
+The separate class `MissionItem` is now just a POD struct inside `Mission`, so `Mission::MissionItem`.
+
+#### Methods
+
+To get the mission progress, the method is now named in the same way as subscriptions in the telemetry plugin,
+old:
+```
+subscribe_mission_progress(subscribe_mission_callback_t callback);
+```
+
+New:
+```
+mission_progress_async(mission_progress_callback_t callback);
+```
+
+The interface to upload a mission no longer uses a `std::vector` of `std::shared_ptr`s but a `std::vector` of the actual structs.
+It is further wrapped inside `MissionPlan` in order to support mission settings.
+
+Old:
+```
+typedef std::function<void(Result)> result_callback_t;
+
+upload_mission_async(std::vector<std::shared_ptr<MissionItem>> items, result_callback_t callback);
+```
+
+New:
+```
+struct MissionPlan {
+    std::vector<MissionItem> mission_items;
+}
+
+upload_mission_async(Mission::MissionPlan mission_plan, result_callback_t callback);
+```
+
+Similarly to download a mission:
+```
+typedef std::function<void(Result, std::vector<MissionItem>)> mission_items_and_result_callback_t;
+
+download_mission_async(mission_items_and_result_callback_t, callback)
+```
+
+New:
+```
+typedef std::function<void(Result, MissionPlan)> download_mission_callback_t;
+void download_mission_async(const Mission::download_mission_callback_t& callback);
+```
+
+> **Tip** There are now also sync methods to upload and download a mission `upload_mission` and `download_mission`.
+
+Some methods now return a `std::pair<Result, bool>` instead of just a `bool` to cover the case where a request fails, e.g.
+old:
+```
+bool mission_finished();
+```
+
+New:
+```
+std::pair<Result, bool> is_mission_finished();
+```


### PR DESCRIPTION
This adds a page to help with transitioning from one version to the next version.

This is work in progress as we move to auto-generation of the C++ part:

https://github.com/mavlink/MAVSDK/pull/1017
https://github.com/mavlink/MAVSDK/pull/1028
https://github.com/mavlink/MAVSDK/pull/1029
https://github.com/mavlink/MAVSDK/pull/1036