### PR TITLE
Fix up links and examples in develop

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -122,7 +122,7 @@
       * [struct StatusText](api_reference/structmavsdk_1_1_telemetry_1_1_status_text.md)
     * [class Tune](api_reference/classmavsdk_1_1_tune.md)
       * [struct TuneDescription](api_reference/structmavsdk_1_1_tune_1_1_tune_description.md)
-    * [namespace mavsdk (api_reference/globals)](api_reference/namespacemavsdk.md)
+    * [namespace mavsdk (globals)](api_reference/namespacemavsdk.md)
   * [Contributing](contributing/README.md)
     * [Building Source](contributing/build.md)
     * [Testing](contributing/test.md)

--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -62,7 +62,7 @@
       * [struct Version](api_reference/structmavsdk_1_1_info_1_1_version.md)
     * [class LogFiles](api_reference/classmavsdk_1_1_log_files.md)
       * [struct Entry](api_reference/structmavsdk_1_1_log_files_1_1_entry.md)
-      * [struct ProgressData](api_reference/structmavsdk_1_1_geofence_1_1_point.md)
+      * [struct ProgressData](api_reference/structmavsdk_1_1_log_files_1_1_progress_data.md)  
     * [class Ftp](api_reference/classmavsdk_1_1_ftp.md)
     * [class MavlinkPassthrough](api_reference/classmavsdk_1_1_mavlink_passthrough.md)
     * [class Mavsdk](api_reference/classmavsdk_1_1_mavsdk.md)

--- a/en/contributing/plugins.md
+++ b/en/contributing/plugins.md
@@ -218,8 +218,6 @@ add_executable(integration_tests_runner
     async_connect.cpp
     telemetry_simple.cpp
     ...
-    mission_change_speed.cpp
-    mission_survey.cpp
     gimbal.cpp
     transition_multicopter_fixedwing.cpp
     follow_me.cpp

--- a/en/cpp/README.md
+++ b/en/cpp/README.md
@@ -37,11 +37,13 @@ API consumers use [Mavsdk](/api_reference/classmavsdk_1_1_mavsdk.md) to discover
 The most important classes are:
 
 - [Mavsdk](/api_reference/classmavsdk_1_1_mavsdk.md): Discover and connect to vehicles ([System](/api_reference/classmavsdk_1_1_system.md)).
-- [System](/api_reference/classmavsdk_1_1_system.md): Represents a connected vehicle (e.g. a copter or VTOL drone). It provides access to vehicle information and control through the classes listed below.
+- [System](/api_reference/classmavsdk_1_1_system.md): Represents a connected vehicle (e.g. a copter or VTOL drone).
+  It provides access to vehicle information and control through the classes listed below.
 - [Info](/api_reference/classmavsdk_1_1_info.md): Basic version information about the hardware and/or software of a system.
-- [Telemetry](/api_reference/classmavsdk_1_1_telemetry.md): Get vehicle telemetry and state information ([Battery](/api_reference/structmavsdk_1_1_telemetry_1_1_battery.md), [EulerAngle](/api_reference/structmavsdk_1_1_telemetry_1_1_euler_angle.md), [GPSInfo](/api_reference/structmavsdk_1_1_telemetry_1_1_g_p_s_info.md), [GroundSpeedNED](/api_reference/structmavsdk_1_1_telemetry_1_1_ground_speed_n_e_d.md), [Health](/api_reference/structmavsdk_1_1_telemetry_1_1_health.md), [Position](/api_reference/structmavsdk_1_1_telemetry_1_1_position.md), [Quaternion](/api_reference/structmavsdk_1_1_telemetry_1_1_quaternion.md), [RCStatus](/api_reference/structmavsdk_1_1_telemetry_1_1_r_c_status.md)) and set telemetry update rates.
+- [Telemetry](/api_reference/classmavsdk_1_1_telemetry.md): Get vehicle telemetry and state information and set telemetry update rates.
 - [Action](/api_reference/classmavsdk_1_1_action.md): Simple drone actions including arming, taking off, and landing.
-- [Mission](/api_reference/classmavsdk_1_1_mission.md): Waypoint mission creation and upload/download. Missions are created from [MissionItem](/api_reference/classmavsdk_1_1_mission_item.md) objects.
+- [Mission](/api_reference/classmavsdk_1_1_mission.md): Waypoint mission creation and upload/download.
+  Missions are created from [MissionItem](/api_reference/structmavsdk_1_1_mission_1_1_mission_item.md) objects.
 - [Offboard](/api_reference/classmavsdk_1_1_offboard.md): Control a drone with velocity commands.
 - [Geofence](/api_reference/classmavsdk_1_1_geofence.md): Specify a geofence.
 - [Gimbal](/api_reference/classmavsdk_1_1_gimbal.md): Control a gimbal.

--- a/en/examples/README.md
+++ b/en/examples/README.md
@@ -13,8 +13,8 @@ Example | Description
 [Fly QGC Plan Mission](../examples/fly_mission_qgc_plan.md) | Fly a mission imported from a *QGroundControl* mission plan.
 [Follow Me Mode](../examples/follow_me.md) | Demonstrates how to put vehicle in [Follow Me Mode](../guide/follow_me.md) and set the current target position and relative position of the drone.
 [GeoFence Inclusion](https://github.com/mavlink/MAVSDK/tree/{{ book.github_branch }}/examples/geofence_inclusion) | Demonstrates how to define and upload a simple polygonal inclusion GeoFence.
-[MAVLink FTP Client](https://github.com/mavlink/MAVSDK/tree/{{ book.github_branch }}/examples/mavlink_ftp_client) | Demonstrates how to create/use a [MAVLink FTP client](https://mavlink.io/en/services/ftp.html).
-[MAVLink FTP Server](https://github.com/mavlink/MAVSDK/tree/{{ book.github_branch }}/examples/mavlink_ftp_server) | Demonstrates how to start/set up a [MAVLink FTP server](https://mavlink.io/en/services/ftp.html).
+[MAVLink FTP Client](https://github.com/mavlink/MAVSDK/tree/{{ book.github_branch }}/examples/ftp_client) | Demonstrates how to create/use a [MAVLink FTP client](https://mavlink.io/en/services/ftp.html).
+[MAVLink FTP Server](https://github.com/mavlink/MAVSDK/tree/{{ book.github_branch }}/examples/ftp_server) | Demonstrates how to start/set up a [MAVLink FTP server](https://mavlink.io/en/services/ftp.html).
 [Multiple Drones](https://github.com/mavlink/MAVSDK/tree/{{ book.github_branch }}/examples/multiple_drones) | Example to connect multiple vehicles and make them take off and land in parallel.
 [Offboard Velocity Control](../examples/offboard_velocity.md) | Demonstrates how to control a vehicle in Offboard mode using velocity commands (in both the NED and body frames).
 [Takeoff and Land](../examples/takeoff_and_land.md) | Shows basic usage of the SDK (connect to port, detect system (vehicle), arm, takeoff, land, get telemetry)

--- a/en/examples/README.md
+++ b/en/examples/README.md
@@ -13,6 +13,7 @@ Example | Description
 [Fly QGC Plan Mission](../examples/fly_mission_qgc_plan.md) | Fly a mission imported from a *QGroundControl* mission plan.
 [Follow Me Mode](../examples/follow_me.md) | Demonstrates how to put vehicle in [Follow Me Mode](../guide/follow_me.md) and set the current target position and relative position of the drone.
 [GeoFence Inclusion](https://github.com/mavlink/MAVSDK/tree/{{ book.github_branch }}/examples/geofence_inclusion) | Demonstrates how to define and upload a simple polygonal inclusion GeoFence.
+[MAVShell](https://github.com/mavlink/MAVSDK/tree/{{ book.github_branch }}/examples/mavshell) | Creates and starts an interactive shell session.
 [MAVLink FTP Client](https://github.com/mavlink/MAVSDK/tree/{{ book.github_branch }}/examples/ftp_client) | Demonstrates how to create/use a [MAVLink FTP client](https://mavlink.io/en/services/ftp.html).
 [MAVLink FTP Server](https://github.com/mavlink/MAVSDK/tree/{{ book.github_branch }}/examples/ftp_server) | Demonstrates how to start/set up a [MAVLink FTP server](https://mavlink.io/en/services/ftp.html).
 [Multiple Drones](https://github.com/mavlink/MAVSDK/tree/{{ book.github_branch }}/examples/multiple_drones) | Example to connect multiple vehicles and make them take off and land in parallel.

--- a/en/examples/fly_mission.md
+++ b/en/examples/fly_mission.md
@@ -156,7 +156,6 @@ target_link_libraries(fly_mission
 #include <functional>
 #include <future>
 #include <iostream>
-#include <memory>
 
 #define ERROR_CONSOLE_TEXT "\033[31m" // Turn text on console red
 #define TELEMETRY_CONSOLE_TEXT "\033[34m" // Turn text on console blue
@@ -168,20 +167,21 @@ using namespace std::chrono; // for seconds(), milliseconds()
 using namespace std::this_thread; // for sleep_for()
 
 // Handles Action's result
-inline void handle_action_err_exit(Action::Result result, const std::string &message);
+inline void handle_action_err_exit(Action::Result result, const std::string& message);
 // Handles Mission's result
-inline void handle_mission_err_exit(Mission::Result result, const std::string &message);
+inline void handle_mission_err_exit(Mission::Result result, const std::string& message);
 // Handles Connection result
-inline void handle_connection_err_exit(ConnectionResult result, const std::string &message);
+inline void handle_connection_err_exit(ConnectionResult result, const std::string& message);
 
-static std::shared_ptr<MissionItem> make_mission_item(double latitude_deg,
-                                                      double longitude_deg,
-                                                      float relative_altitude_m,
-                                                      float speed_m_s,
-                                                      bool is_fly_through,
-                                                      float gimbal_pitch_deg,
-                                                      float gimbal_yaw_deg,
-                                                      MissionItem::CameraAction camera_action);
+static Mission::MissionItem make_mission_item(
+    double latitude_deg,
+    double longitude_deg,
+    float relative_altitude_m,
+    float speed_m_s,
+    bool is_fly_through,
+    float gimbal_pitch_deg,
+    float gimbal_yaw_deg,
+    Mission::MissionItem::CameraAction camera_action);
 
 void usage(std::string bin_name)
 {
@@ -193,7 +193,7 @@ void usage(std::string bin_name)
               << "For example, to connect to the simulator use URL: udp://:14540" << std::endl;
 }
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
     Mavsdk dc;
 
@@ -218,9 +218,8 @@ int main(int argc, char **argv)
             return 1;
         }
 
-        if (connection_result != ConnectionResult::SUCCESS) {
-            std::cout << ERROR_CONSOLE_TEXT
-                      << "Connection failed: " << connection_result_str(connection_result)
+        if (connection_result != ConnectionResult::Success) {
+            std::cout << ERROR_CONSOLE_TEXT << "Connection failed: " << connection_result
                       << NORMAL_CONSOLE_TEXT << std::endl;
             return 1;
         }
@@ -237,7 +236,7 @@ int main(int argc, char **argv)
     // We don't need to specifiy the UUID if it's only one system anyway.
     // If there were multiple, we could specify it with:
     // dc.system(uint64_t uuid);
-    System &system = dc.system();
+    System& system = dc.system();
     auto action = std::make_shared<Action>(system);
     auto mission = std::make_shared<Mission>(system);
     auto telemetry = std::make_shared<Telemetry>(system);
@@ -250,61 +249,67 @@ int main(int argc, char **argv)
     std::cout << "System ready" << std::endl;
     std::cout << "Creating and uploading mission" << std::endl;
 
-    std::vector<std::shared_ptr<MissionItem>> mission_items;
+    std::vector<Mission::MissionItem> mission_items;
 
-    mission_items.push_back(make_mission_item(47.398170327054473,
-                                              8.5456490218639658,
-                                              10.0f,
-                                              5.0f,
-                                              false,
-                                              20.0f,
-                                              60.0f,
-                                              MissionItem::CameraAction::NONE));
+    mission_items.push_back(make_mission_item(
+        47.398170327054473,
+        8.5456490218639658,
+        10.0f,
+        5.0f,
+        false,
+        20.0f,
+        60.0f,
+        Mission::MissionItem::CameraAction::None));
 
-    mission_items.push_back(make_mission_item(47.398241338125118,
-                                              8.5455360114574432,
-                                              10.0f,
-                                              2.0f,
-                                              true,
-                                              0.0f,
-                                              -60.0f,
-                                              MissionItem::CameraAction::TAKE_PHOTO));
+    mission_items.push_back(make_mission_item(
+        47.398241338125118,
+        8.5455360114574432,
+        10.0f,
+        2.0f,
+        true,
+        0.0f,
+        -60.0f,
+        Mission::MissionItem::CameraAction::TakePhoto));
 
-    mission_items.push_back(make_mission_item(47.398139363821485,
-                                              8.5453846156597137,
-                                              10.0f,
-                                              5.0f,
-                                              true,
-                                              -45.0f,
-                                              0.0f,
-                                              MissionItem::CameraAction::START_VIDEO));
+    mission_items.push_back(make_mission_item(
+        47.398139363821485,
+        8.5453846156597137,
+        10.0f,
+        5.0f,
+        true,
+        -45.0f,
+        0.0f,
+        Mission::MissionItem::CameraAction::StartVideo));
 
-    mission_items.push_back(make_mission_item(47.398058617228855,
-                                              8.5454618036746979,
-                                              10.0f,
-                                              2.0f,
-                                              false,
-                                              -90.0f,
-                                              30.0f,
-                                              MissionItem::CameraAction::STOP_VIDEO));
+    mission_items.push_back(make_mission_item(
+        47.398058617228855,
+        8.5454618036746979,
+        10.0f,
+        2.0f,
+        false,
+        -90.0f,
+        30.0f,
+        Mission::MissionItem::CameraAction::StopVideo));
 
-    mission_items.push_back(make_mission_item(47.398100366082858,
-                                              8.5456969141960144,
-                                              10.0f,
-                                              5.0f,
-                                              false,
-                                              -45.0f,
-                                              -30.0f,
-                                              MissionItem::CameraAction::START_PHOTO_INTERVAL));
+    mission_items.push_back(make_mission_item(
+        47.398100366082858,
+        8.5456969141960144,
+        10.0f,
+        5.0f,
+        false,
+        -45.0f,
+        -30.0f,
+        Mission::MissionItem::CameraAction::StartPhotoInterval));
 
-    mission_items.push_back(make_mission_item(47.398001890458097,
-                                              8.5455576181411743,
-                                              10.0f,
-                                              5.0f,
-                                              false,
-                                              0.0f,
-                                              0.0f,
-                                              MissionItem::CameraAction::STOP_PHOTO_INTERVAL));
+    mission_items.push_back(make_mission_item(
+        47.398001890458097,
+        8.5455576181411743,
+        10.0f,
+        5.0f,
+        false,
+        0.0f,
+        0.0f,
+        Mission::MissionItem::CameraAction::StopPhotoInterval));
 
     {
         std::cout << "Uploading mission..." << std::endl;
@@ -312,13 +317,14 @@ int main(int argc, char **argv)
         // std::future.
         auto prom = std::make_shared<std::promise<Mission::Result>>();
         auto future_result = prom->get_future();
-        mission->upload_mission_async(mission_items,
-                                      [prom](Mission::Result result) { prom->set_value(result); });
+        Mission::MissionPlan mission_plan{};
+        mission_plan.mission_items = mission_items;
+        mission->upload_mission_async(
+            mission_plan, [prom](Mission::Result result) { prom->set_value(result); });
 
         const Mission::Result result = future_result.get();
-        if (result != Mission::Result::SUCCESS) {
-            std::cout << "Mission upload failed (" << Mission::result_str(result) << "), exiting."
-                      << std::endl;
+        if (result != Mission::Result::Success) {
+            std::cout << "Mission upload failed (" << result << "), exiting." << std::endl;
             return 1;
         }
         std::cout << "Mission uploaded." << std::endl;
@@ -331,15 +337,17 @@ int main(int argc, char **argv)
 
     std::atomic<bool> want_to_pause{false};
     // Before starting the mission, we want to be sure to subscribe to the mission progress.
-    mission->subscribe_progress([&want_to_pause](int current, int total) {
-        std::cout << "Mission status update: " << current << " / " << total << std::endl;
+    mission->subscribe_mission_progress(
+        [&want_to_pause](Mission::MissionProgress mission_progress) {
+            std::cout << "Mission status update: " << mission_progress.current << " / "
+                      << mission_progress.total << std::endl;
 
-        if (current >= 2) {
-            // We can only set a flag here. If we do more request inside the callback,
-            // we risk blocking the system.
-            want_to_pause = true;
-        }
-    });
+            if (mission_progress.current >= 2) {
+                // We can only set a flag here. If we do more request inside the callback,
+                // we risk blocking the system.
+                want_to_pause = true;
+            }
+        });
 
     {
         std::cout << "Starting mission." << std::endl;
@@ -366,9 +374,8 @@ int main(int argc, char **argv)
         mission->pause_mission_async([prom](Mission::Result result) { prom->set_value(result); });
 
         const Mission::Result result = future_result.get();
-        if (result != Mission::Result::SUCCESS) {
-            std::cout << "Failed to pause mission (" << Mission::result_str(result) << ")"
-                      << std::endl;
+        if (result != Mission::Result::Success) {
+            std::cout << "Failed to pause mission (" << result << ")" << std::endl;
         } else {
             std::cout << "Mission paused." << std::endl;
         }
@@ -386,15 +393,14 @@ int main(int argc, char **argv)
         mission->start_mission_async([prom](Mission::Result result) { prom->set_value(result); });
 
         const Mission::Result result = future_result.get();
-        if (result != Mission::Result::SUCCESS) {
-            std::cout << "Failed to resume mission (" << Mission::result_str(result) << ")"
-                      << std::endl;
+        if (result != Mission::Result::Success) {
+            std::cout << "Failed to resume mission (" << result << ")" << std::endl;
         } else {
             std::cout << "Resumed mission." << std::endl;
         }
     }
 
-    while (!mission->mission_finished()) {
+    while (!mission->is_mission_finished().second) {
         sleep_for(seconds(1));
     }
 
@@ -403,8 +409,7 @@ int main(int argc, char **argv)
         std::cout << "Commanding RTL..." << std::endl;
         const Action::Result result = action->return_to_launch();
         if (result != Action::Result::Success) {
-            std::cout << "Failed to command RTL (" << Action::result_str(result) << ")"
-                      << std::endl;
+            std::cout << "Failed to command RTL (" << result << ")" << std::endl;
         } else {
             std::cout << "Commanded RTL." << std::endl;
         }
@@ -420,49 +425,49 @@ int main(int argc, char **argv)
     std::cout << "Disarmed, exiting." << std::endl;
 }
 
-std::shared_ptr<MissionItem> make_mission_item(double latitude_deg,
-                                               double longitude_deg,
-                                               float relative_altitude_m,
-                                               float speed_m_s,
-                                               bool is_fly_through,
-                                               float gimbal_pitch_deg,
-                                               float gimbal_yaw_deg,
-                                               MissionItem::CameraAction camera_action)
+Mission::MissionItem make_mission_item(
+    double latitude_deg,
+    double longitude_deg,
+    float relative_altitude_m,
+    float speed_m_s,
+    bool is_fly_through,
+    float gimbal_pitch_deg,
+    float gimbal_yaw_deg,
+    Mission::MissionItem::CameraAction camera_action)
 {
-    std::shared_ptr<MissionItem> new_item(new MissionItem());
-    new_item->set_position(latitude_deg, longitude_deg);
-    new_item->set_relative_altitude(relative_altitude_m);
-    new_item->set_speed(speed_m_s);
-    new_item->set_fly_through(is_fly_through);
-    new_item->set_gimbal_pitch_and_yaw(gimbal_pitch_deg, gimbal_yaw_deg);
-    new_item->set_camera_action(camera_action);
+    Mission::MissionItem new_item{};
+    new_item.latitude_deg = latitude_deg;
+    new_item.longitude_deg = longitude_deg;
+    new_item.relative_altitude_m = relative_altitude_m;
+    new_item.speed_m_s = speed_m_s;
+    new_item.is_fly_through = is_fly_through;
+    new_item.gimbal_pitch_deg = gimbal_pitch_deg;
+    new_item.gimbal_yaw_deg = gimbal_yaw_deg;
+    new_item.camera_action = camera_action;
     return new_item;
 }
 
-inline void handle_action_err_exit(Action::Result result, const std::string &message)
+inline void handle_action_err_exit(Action::Result result, const std::string& message)
 {
     if (result != Action::Result::Success) {
-        std::cerr << ERROR_CONSOLE_TEXT << message << Action::result_str(result)
-                  << NORMAL_CONSOLE_TEXT << std::endl;
+        std::cerr << ERROR_CONSOLE_TEXT << message << result << NORMAL_CONSOLE_TEXT << std::endl;
         exit(EXIT_FAILURE);
     }
 }
 
-inline void handle_mission_err_exit(Mission::Result result, const std::string &message)
+inline void handle_mission_err_exit(Mission::Result result, const std::string& message)
 {
-    if (result != Mission::Result::SUCCESS) {
-        std::cerr << ERROR_CONSOLE_TEXT << message << Mission::result_str(result)
-                  << NORMAL_CONSOLE_TEXT << std::endl;
+    if (result != Mission::Result::Success) {
+        std::cerr << ERROR_CONSOLE_TEXT << message << result << NORMAL_CONSOLE_TEXT << std::endl;
         exit(EXIT_FAILURE);
     }
 }
 
 // Handles connection result
-inline void handle_connection_err_exit(ConnectionResult result, const std::string &message)
+inline void handle_connection_err_exit(ConnectionResult result, const std::string& message)
 {
-    if (result != ConnectionResult::SUCCESS) {
-        std::cerr << ERROR_CONSOLE_TEXT << message << connection_result_str(result)
-                  << NORMAL_CONSOLE_TEXT << std::endl;
+    if (result != ConnectionResult::Success) {
+        std::cerr << ERROR_CONSOLE_TEXT << message << result << NORMAL_CONSOLE_TEXT << std::endl;
         exit(EXIT_FAILURE);
     }
 }

--- a/en/examples/fly_mission_qgc_plan.md
+++ b/en/examples/fly_mission_qgc_plan.md
@@ -176,11 +176,11 @@ using namespace std::chrono; // for seconds(), milliseconds()
 using namespace std::this_thread; // for sleep_for()
 
 // Handles Action's result
-inline void handle_action_err_exit(Action::Result result, const std::string &message);
+inline void handle_action_err_exit(Action::Result result, const std::string& message);
 // Handles Mission's result
-inline void handle_mission_err_exit(Mission::Result result, const std::string &message);
+inline void handle_mission_err_exit(Mission::Result result, const std::string& message);
 // Handles Connection result
-inline void handle_connection_err_exit(ConnectionResult result, const std::string &message);
+inline void handle_connection_err_exit(ConnectionResult result, const std::string& message);
 
 void usage(std::string bin_name)
 {
@@ -193,14 +193,14 @@ void usage(std::string bin_name)
               << "For example, to connect to the simulator use URL: udp://:14540" << std::endl;
 }
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
     Mavsdk dc;
     std::string connection_url;
     ConnectionResult connection_result;
 
     // Locate path of QGC Sample plan
-    std::string qgc_plan = "../../../src/plugins/mission/qgroundcontrol_sample.plan";
+    std::string qgc_plan = "../../../plugins/mission/qgroundcontrol_sample.plan";
 
     if (argc != 2 && argc != 3) {
         usage(argv[0]);
@@ -240,7 +240,7 @@ int main(int argc, char **argv)
     // We don't need to specify the UUID if it's only one system anyway.
     // If there were multiple, we could specify it with:
     // dc.system(uint64_t uuid);
-    System &system = dc.system();
+    System& system = dc.system();
     auto action = std::make_shared<Action>(system);
     auto mission = std::make_shared<Mission>(system);
     auto telemetry = std::make_shared<Telemetry>(system);
@@ -253,24 +253,24 @@ int main(int argc, char **argv)
     std::cout << "System ready" << std::endl;
 
     // Import Mission items from QGC plan
-    Mission::mission_items_t mission_items;
-    Mission::Result import_res = Mission::import_qgroundcontrol_mission(mission_items, qgc_plan);
-    handle_mission_err_exit(import_res, "Failed to import mission items: ");
+    std::pair<Mission::Result, Mission::MissionPlan> import_res =
+        mission->import_qgroundcontrol_mission(qgc_plan);
+    handle_mission_err_exit(import_res.first, "Failed to import mission items: ");
 
-    if (mission_items.size() == 0) {
+    if (import_res.second.mission_items.size() == 0) {
         std::cerr << "No missions! Exiting..." << std::endl;
         exit(EXIT_FAILURE);
     }
-    std::cout << "Found " << mission_items.size() << " mission items in the given QGC plan."
-              << std::endl;
+    std::cout << "Found " << import_res.second.mission_items.size()
+              << " mission items in the given QGC plan." << std::endl;
 
     {
         std::cout << "Uploading mission..." << std::endl;
         // Wrap the asynchronous upload_mission function using std::future.
         auto prom = std::make_shared<std::promise<Mission::Result>>();
         auto future_result = prom->get_future();
-        mission->upload_mission_async(mission_items,
-                                      [prom](Mission::Result result) { prom->set_value(result); });
+        mission->upload_mission_async(
+            import_res.second, [prom](Mission::Result result) { prom->set_value(result); });
 
         const Mission::Result result = future_result.get();
         handle_mission_err_exit(result, "Mission upload failed: ");
@@ -283,8 +283,9 @@ int main(int argc, char **argv)
     std::cout << "Armed." << std::endl;
 
     // Before starting the mission subscribe to the mission progress.
-    mission->subscribe_progress([](int current, int total) {
-        std::cout << "Mission status update: " << current << " / " << total << std::endl;
+    mission->subscribe_mission_progress([](Mission::MissionProgress mission_progress) {
+        std::cout << "Mission status update: " << mission_progress.current << " / "
+                  << mission_progress.total << std::endl;
     });
 
     {
@@ -300,7 +301,7 @@ int main(int argc, char **argv)
         handle_mission_err_exit(result, "Mission start failed: ");
     }
 
-    while (!mission->mission_finished()) {
+    while (!mission->is_mission_finished().second) {
         sleep_for(seconds(1));
     }
 
@@ -312,8 +313,7 @@ int main(int argc, char **argv)
         std::cout << "Commanding RTL..." << std::endl;
         const Action::Result result = action->return_to_launch();
         if (result != Action::Result::Success) {
-            std::cout << "Failed to command RTL (" << Action::result_str(result) << ")"
-                      << std::endl;
+            std::cout << "Failed to command RTL (" << result << ")" << std::endl;
         } else {
             std::cout << "Commanded RTL." << std::endl;
         }
@@ -322,30 +322,27 @@ int main(int argc, char **argv)
     return 0;
 }
 
-inline void handle_action_err_exit(Action::Result result, const std::string &message)
+inline void handle_action_err_exit(Action::Result result, const std::string& message)
 {
     if (result != Action::Result::Success) {
-        std::cerr << ERROR_CONSOLE_TEXT << message << Action::result_str(result)
-                  << NORMAL_CONSOLE_TEXT << std::endl;
+        std::cerr << ERROR_CONSOLE_TEXT << message << result << NORMAL_CONSOLE_TEXT << std::endl;
         exit(EXIT_FAILURE);
     }
 }
 
-inline void handle_mission_err_exit(Mission::Result result, const std::string &message)
+inline void handle_mission_err_exit(Mission::Result result, const std::string& message)
 {
-    if (result != Mission::Result::SUCCESS) {
-        std::cerr << ERROR_CONSOLE_TEXT << message << Mission::result_str(result)
-                  << NORMAL_CONSOLE_TEXT << std::endl;
+    if (result != Mission::Result::Success) {
+        std::cerr << ERROR_CONSOLE_TEXT << message << result << NORMAL_CONSOLE_TEXT << std::endl;
         exit(EXIT_FAILURE);
     }
 }
 
 // Handles connection result
-inline void handle_connection_err_exit(ConnectionResult result, const std::string &message)
+inline void handle_connection_err_exit(ConnectionResult result, const std::string& message)
 {
-    if (result != ConnectionResult::SUCCESS) {
-        std::cerr << ERROR_CONSOLE_TEXT << message << connection_result_str(result)
-                  << NORMAL_CONSOLE_TEXT << std::endl;
+    if (result != ConnectionResult::Success) {
+        std::cerr << ERROR_CONSOLE_TEXT << message << result << NORMAL_CONSOLE_TEXT << std::endl;
         exit(EXIT_FAILURE);
     }
 }

--- a/en/examples/offboard_velocity.md
+++ b/en/examples/offboard_velocity.md
@@ -99,15 +99,16 @@ target_link_libraries(offboard
 ```cpp
 /**
  * @file offboard_velocity.cpp
- * @brief Example that demonstrates offboard velocity control in local NED and body coordinates
+ * @brief Example that demonstrates offboard velocity control in local NED and
+ * body coordinates
  *
  * @authors Author: Julian Oes <julian@oes.ch>,
  *                  Shakthi Prashanth <shakthi.prashanth.m@intel.com>
- * @date 2017-10-17
  */
 
 #include <chrono>
 #include <cmath>
+#include <future>
 #include <iostream>
 #include <thread>
 
@@ -117,46 +118,43 @@ target_link_libraries(offboard
 #include <mavsdk/plugins/telemetry/telemetry.h>
 
 using namespace mavsdk;
-using std::this_thread::sleep_for;
 using std::chrono::milliseconds;
 using std::chrono::seconds;
+using std::this_thread::sleep_for;
 
 #define ERROR_CONSOLE_TEXT "\033[31m" // Turn text on console red
 #define TELEMETRY_CONSOLE_TEXT "\033[34m" // Turn text on console blue
 #define NORMAL_CONSOLE_TEXT "\033[0m" // Restore normal console colour
 
 // Handles Action's result
-inline void action_error_exit(Action::Result result, const std::string &message)
+inline void action_error_exit(Action::Result result, const std::string& message)
 {
     if (result != Action::Result::Success) {
-        std::cerr << ERROR_CONSOLE_TEXT << message << Action::result_str(result)
-                  << NORMAL_CONSOLE_TEXT << std::endl;
+        std::cerr << ERROR_CONSOLE_TEXT << message << result << NORMAL_CONSOLE_TEXT << std::endl;
         exit(EXIT_FAILURE);
     }
 }
 
 // Handles Offboard's result
-inline void offboard_error_exit(Offboard::Result result, const std::string &message)
+inline void offboard_error_exit(Offboard::Result result, const std::string& message)
 {
-    if (result != Offboard::Result::SUCCESS) {
-        std::cerr << ERROR_CONSOLE_TEXT << message << Offboard::result_str(result)
-                  << NORMAL_CONSOLE_TEXT << std::endl;
+    if (result != Offboard::Result::Success) {
+        std::cerr << ERROR_CONSOLE_TEXT << message << result << NORMAL_CONSOLE_TEXT << std::endl;
         exit(EXIT_FAILURE);
     }
 }
 
 // Handles connection result
-inline void connection_error_exit(ConnectionResult result, const std::string &message)
+inline void connection_error_exit(ConnectionResult result, const std::string& message)
 {
-    if (result != ConnectionResult::SUCCESS) {
-        std::cerr << ERROR_CONSOLE_TEXT << message << connection_result_str(result)
-                  << NORMAL_CONSOLE_TEXT << std::endl;
+    if (result != ConnectionResult::Success) {
+        std::cerr << ERROR_CONSOLE_TEXT << message << result << NORMAL_CONSOLE_TEXT << std::endl;
         exit(EXIT_FAILURE);
     }
 }
 
 // Logs during Offboard control
-inline void offboard_log(const std::string &offb_mode, const std::string msg)
+inline void offboard_log(const std::string& offb_mode, const std::string msg)
 {
     std::cout << "[" << offb_mode << "] " << msg << std::endl;
 }
@@ -164,20 +162,25 @@ inline void offboard_log(const std::string &offb_mode, const std::string msg)
 /**
  * Does Offboard control using NED co-ordinates.
  *
- * returns true if everything went well in Offboard control, exits with a log otherwise.
+ * returns true if everything went well in Offboard control, exits with a log
+ * otherwise.
  */
 bool offb_ctrl_ned(std::shared_ptr<mavsdk::Offboard> offboard)
 {
     const std::string offb_mode = "NED";
     // Send it once before starting offboard, otherwise it will be rejected.
-    offboard->set_velocity_ned({0.0f, 0.0f, 0.0f, 0.0f});
+    const Offboard::VelocityNedYaw stay{};
+    offboard->set_velocity_ned(stay);
 
     Offboard::Result offboard_result = offboard->start();
     offboard_error_exit(offboard_result, "Offboard start failed");
     offboard_log(offb_mode, "Offboard started");
 
     offboard_log(offb_mode, "Turn to face East");
-    offboard->set_velocity_ned({0.0f, 0.0f, 0.0f, 90.0f});
+
+    Offboard::VelocityNedYaw turn_east{};
+    turn_east.yaw_deg = 90.0f;
+    offboard->set_velocity_ned(turn_east);
     sleep_for(seconds(1)); // Let yaw settle.
 
     {
@@ -188,21 +191,31 @@ bool offb_ctrl_ned(std::shared_ptr<mavsdk::Offboard> offboard)
         offboard_log(offb_mode, "Go North and back South");
         for (unsigned i = 0; i < steps; ++i) {
             float vx = 5.0f * sinf(i * step_size);
-            offboard->set_velocity_ned({vx, 0.0f, 0.0f, 90.0f});
+            Offboard::VelocityNedYaw north_and_back_south{};
+            north_and_back_south.north_m_s = vx;
+            north_and_back_south.yaw_deg = 90.0f;
+            offboard->set_velocity_ned(north_and_back_south);
             sleep_for(milliseconds(10));
         }
     }
 
     offboard_log(offb_mode, "Turn to face West");
-    offboard->set_velocity_ned({0.0f, 0.0f, 0.0f, 270.0f});
+    Offboard::VelocityNedYaw turn_west{};
+    turn_west.yaw_deg = 270.0f;
+    offboard->set_velocity_ned(turn_west);
     sleep_for(seconds(2));
 
     offboard_log(offb_mode, "Go up 2 m/s, turn to face South");
-    offboard->set_velocity_ned({0.0f, 0.0f, -2.0f, 180.0f});
+    Offboard::VelocityNedYaw up_and_south{};
+    up_and_south.down_m_s = -2.0f;
+    up_and_south.yaw_deg = 180.0f;
+    offboard->set_velocity_ned(up_and_south);
     sleep_for(seconds(4));
 
     offboard_log(offb_mode, "Go down 1 m/s, turn to face North");
-    offboard->set_velocity_ned({0.0f, 0.0f, 1.0f, 0.0f});
+    Offboard::VelocityNedYaw down_and_north{};
+    up_and_south.down_m_s = 1.0f;
+    offboard->set_velocity_ned(down_and_north);
     sleep_for(seconds(4));
 
     // Now, stop offboard mode.
@@ -216,45 +229,58 @@ bool offb_ctrl_ned(std::shared_ptr<mavsdk::Offboard> offboard)
 /**
  * Does Offboard control using body co-ordinates.
  *
- * returns true if everything went well in Offboard control, exits with a log otherwise.
+ * returns true if everything went well in Offboard control, exits with a log
+ * otherwise.
  */
 bool offb_ctrl_body(std::shared_ptr<mavsdk::Offboard> offboard)
 {
     const std::string offb_mode = "BODY";
 
     // Send it once before starting offboard, otherwise it will be rejected.
-    offboard->set_velocity_body({0.0f, 0.0f, 0.0f, 0.0f});
+    Offboard::VelocityBodyYawspeed stay{};
+    offboard->set_velocity_body(stay);
 
     Offboard::Result offboard_result = offboard->start();
     offboard_error_exit(offboard_result, "Offboard start failed: ");
     offboard_log(offb_mode, "Offboard started");
 
     offboard_log(offb_mode, "Turn clock-wise and climb");
-    offboard->set_velocity_body({0.0f, 0.0f, -1.0f, 60.0f});
+    Offboard::VelocityBodyYawspeed cc_and_climb{};
+    cc_and_climb.down_m_s = -1.0f;
+    cc_and_climb.yawspeed_deg_s = 60.0f;
+    offboard->set_velocity_body(cc_and_climb);
     sleep_for(seconds(5));
 
     offboard_log(offb_mode, "Turn back anti-clockwise");
-    offboard->set_velocity_body({0.0f, 0.0f, 0.0f, -60.0f});
+    Offboard::VelocityBodyYawspeed ccw{};
+    ccw.down_m_s = -1.0f;
+    ccw.yawspeed_deg_s = -60.0f;
+    offboard->set_velocity_body(ccw);
     sleep_for(seconds(5));
 
     offboard_log(offb_mode, "Wait for a bit");
-    offboard->set_velocity_body({0.0f, 0.0f, 0.0f, 0.0f});
+    offboard->set_velocity_body(stay);
     sleep_for(seconds(2));
 
     offboard_log(offb_mode, "Fly a circle");
-    offboard->set_velocity_body({5.0f, 0.0f, 0.0f, 30.0f});
+    Offboard::VelocityBodyYawspeed circle{};
+    circle.forward_m_s = 5.0f;
+    circle.yawspeed_deg_s = 30.0f;
+    offboard->set_velocity_body(circle);
     sleep_for(seconds(15));
 
     offboard_log(offb_mode, "Wait for a bit");
-    offboard->set_velocity_body({0.0f, 0.0f, 0.0f, 0.0f});
+    offboard->set_velocity_body(stay);
     sleep_for(seconds(5));
 
     offboard_log(offb_mode, "Fly a circle sideways");
-    offboard->set_velocity_body({0.0f, -5.0f, 0.0f, 30.0f});
+    circle.right_m_s = -5.0f;
+    circle.yawspeed_deg_s = 30.0f;
+    offboard->set_velocity_body(circle);
     sleep_for(seconds(15));
 
     offboard_log(offb_mode, "Wait for a bit");
-    offboard->set_velocity_body({0.0f, 0.0f, 0.0f, 0.0f});
+    offboard->set_velocity_body(stay);
     sleep_for(seconds(8));
 
     offboard_result = offboard->stop();
@@ -267,29 +293,35 @@ bool offb_ctrl_body(std::shared_ptr<mavsdk::Offboard> offboard)
 /**
  * Does Offboard control using attitude commands.
  *
- * returns true if everything went well in Offboard control, exits with a log otherwise.
+ * returns true if everything went well in Offboard control, exits with a log
+ * otherwise.
  */
 bool offb_ctrl_attitude(std::shared_ptr<mavsdk::Offboard> offboard)
 {
     const std::string offb_mode = "ATTITUDE";
 
     // Send it once before starting offboard, otherwise it will be rejected.
-    offboard->set_attitude({30.0f, 0.0f, 0.0f, 0.6f});
+    Offboard::Attitude roll{};
+    roll.roll_deg = 30.0f;
+    roll.thrust_value = 0.6f;
+    offboard->set_attitude(roll);
 
     Offboard::Result offboard_result = offboard->start();
     offboard_error_exit(offboard_result, "Offboard start failed");
     offboard_log(offb_mode, "Offboard started");
 
     offboard_log(offb_mode, "ROLL 30");
-    offboard->set_attitude({30.0f, 0.0f, 0.0f, 0.6f});
+    offboard->set_attitude(roll);
     sleep_for(seconds(2)); // rolling
 
     offboard_log(offb_mode, "ROLL -30");
-    offboard->set_attitude({-30.0f, 0.0f, 0.0f, 0.6f});
+    roll.roll_deg = -30.0f;
+    offboard->set_attitude(roll);
     sleep_for(seconds(2)); // Let yaw settle.
 
     offboard_log(offb_mode, "ROLL 0");
-    offboard->set_attitude({0.0f, 0.0f, 0.0f, 0.6f});
+    roll.roll_deg = 0.0f;
+    offboard->set_attitude(roll);
     sleep_for(seconds(2)); // Let yaw settle.
 
     // Now, stop offboard mode.
@@ -298,6 +330,20 @@ bool offb_ctrl_attitude(std::shared_ptr<mavsdk::Offboard> offboard)
     offboard_log(offb_mode, "Offboard stopped");
 
     return true;
+}
+
+void wait_until_discover(Mavsdk& dc)
+{
+    std::cout << "Waiting to discover system..." << std::endl;
+    std::promise<void> discover_promise;
+    auto discover_future = discover_promise.get_future();
+
+    dc.register_on_discover([&discover_promise](uint64_t uuid) {
+        std::cout << "Discovered system with UUID: " << uuid << std::endl;
+        discover_promise.set_value();
+    });
+
+    discover_future.wait();
 }
 
 void usage(std::string bin_name)
@@ -310,7 +356,33 @@ void usage(std::string bin_name)
               << "For example, to connect to the simulator use URL: udp://:14540" << std::endl;
 }
 
-int main(int argc, char **argv)
+Telemetry::LandedStateCallback
+landed_state_callback(std::shared_ptr<Telemetry>& telemetry, std::promise<void>& landed_promise)
+{
+    return [&landed_promise, &telemetry](Telemetry::LandedState landed) {
+        switch (landed) {
+            case Telemetry::LandedState::OnGround:
+                std::cout << "On ground" << std::endl;
+                break;
+            case Telemetry::LandedState::TakingOff:
+                std::cout << "Taking off..." << std::endl;
+                break;
+            case Telemetry::LandedState::Landing:
+                std::cout << "Landing..." << std::endl;
+                break;
+            case Telemetry::LandedState::InAir:
+                std::cout << "Taking off has finished." << std::endl;
+                telemetry->subscribe_landed_state(nullptr);
+                landed_promise.set_value();
+                break;
+            case Telemetry::LandedState::Unknown:
+                std::cout << "Unknown landed state." << std::endl;
+                break;
+        }
+    };
+}
+
+int main(int argc, char** argv)
 {
     Mavsdk dc;
     std::string connection_url;
@@ -324,21 +396,17 @@ int main(int argc, char **argv)
         return 1;
     }
 
-    if (connection_result != ConnectionResult::SUCCESS) {
-        std::cout << ERROR_CONSOLE_TEXT
-                  << "Connection failed: " << connection_result_str(connection_result)
+    if (connection_result != ConnectionResult::Success) {
+        std::cout << ERROR_CONSOLE_TEXT << "Connection failed: " << connection_result
                   << NORMAL_CONSOLE_TEXT << std::endl;
         return 1;
     }
 
     // Wait for the system to connect via heartbeat
-    while (!dc.is_connected()) {
-        std::cout << "Wait for system to connect via heartbeat" << std::endl;
-        sleep_for(seconds(1));
-    }
+    wait_until_discover(dc);
 
     // System got discovered.
-    System &system = dc.system();
+    System& system = dc.system();
     auto action = std::make_shared<Action>(system);
     auto offboard = std::make_shared<Offboard>(system);
     auto telemetry = std::make_shared<Telemetry>(system);
@@ -349,14 +417,18 @@ int main(int argc, char **argv)
     }
     std::cout << "System is ready" << std::endl;
 
+    std::promise<void> in_air_promise;
+    auto in_air_future = in_air_promise.get_future();
+
     Action::Result arm_result = action->arm();
     action_error_exit(arm_result, "Arming failed");
     std::cout << "Armed" << std::endl;
 
     Action::Result takeoff_result = action->takeoff();
     action_error_exit(takeoff_result, "Takeoff failed");
-    std::cout << "In Air..." << std::endl;
-    sleep_for(seconds(5));
+
+    telemetry->subscribe_landed_state(landed_state_callback(telemetry, in_air_promise));
+    in_air_future.wait();
 
     //  using attitude control
     bool ret = offb_ctrl_attitude(offboard);
@@ -386,7 +458,8 @@ int main(int argc, char **argv)
     }
     std::cout << "Landed!" << std::endl;
 
-    // We are relying on auto-disarming but let's keep watching the telemetry for a bit longer.
+    // We are relying on auto-disarming but let's keep watching the telemetry for
+    // a bit longer.
     sleep_for(seconds(3));
     std::cout << "Finished..." << std::endl;
 

--- a/en/examples/takeoff_and_land.md
+++ b/en/examples/takeoff_and_land.md
@@ -124,7 +124,7 @@ void component_discovered(ComponentType component_type)
               << unsigned(component_type) << std::endl;
 }
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
     Mavsdk dc;
     std::string connection_url;
@@ -139,9 +139,8 @@ int main(int argc, char **argv)
         return 1;
     }
 
-    if (connection_result != ConnectionResult::SUCCESS) {
-        std::cout << ERROR_CONSOLE_TEXT
-                  << "Connection failed: " << connection_result_str(connection_result)
+    if (connection_result != ConnectionResult::Success) {
+        std::cout << ERROR_CONSOLE_TEXT << "Connection failed: " << connection_result
                   << NORMAL_CONSOLE_TEXT << std::endl;
         return 1;
     }
@@ -149,7 +148,7 @@ int main(int argc, char **argv)
     // We don't need to specify the UUID if it's only one system anyway.
     // If there were multiple, we could specify it with:
     // dc.system(uint64_t uuid);
-    System &system = dc.system();
+    System& system = dc.system();
 
     std::cout << "Waiting to discover system..." << std::endl;
     dc.register_on_discover([&discovered_system](uint64_t uuid) {
@@ -176,15 +175,14 @@ int main(int argc, char **argv)
 
     // We want to listen to the altitude of the drone at 1 Hz.
     const Telemetry::Result set_rate_result = telemetry->set_rate_position(1.0);
-    if (set_rate_result != Telemetry::Result::SUCCESS) {
-        std::cout << ERROR_CONSOLE_TEXT
-                  << "Setting rate failed:" << Telemetry::result_str(set_rate_result)
+    if (set_rate_result != Telemetry::Result::Success) {
+        std::cout << ERROR_CONSOLE_TEXT << "Setting rate failed:" << set_rate_result
                   << NORMAL_CONSOLE_TEXT << std::endl;
         return 1;
     }
 
     // Set up callback to monitor altitude while the vehicle is in flight
-    telemetry->position_async([](Telemetry::Position position) {
+    telemetry->subscribe_position([](Telemetry::Position position) {
         std::cout << TELEMETRY_CONSOLE_TEXT // set to blue
                   << "Altitude: " << position.relative_altitude_m << " m"
                   << NORMAL_CONSOLE_TEXT // set to default color again
@@ -202,8 +200,8 @@ int main(int argc, char **argv)
     const Action::Result arm_result = action->arm();
 
     if (arm_result != Action::Result::Success) {
-        std::cout << ERROR_CONSOLE_TEXT << "Arming failed:" << Action::result_str(arm_result)
-                  << NORMAL_CONSOLE_TEXT << std::endl;
+        std::cout << ERROR_CONSOLE_TEXT << "Arming failed:" << arm_result << NORMAL_CONSOLE_TEXT
+                  << std::endl;
         return 1;
     }
 
@@ -211,7 +209,7 @@ int main(int argc, char **argv)
     std::cout << "Taking off..." << std::endl;
     const Action::Result takeoff_result = action->takeoff();
     if (takeoff_result != Action::Result::Success) {
-        std::cout << ERROR_CONSOLE_TEXT << "Takeoff failed:" << Action::result_str(takeoff_result)
+        std::cout << ERROR_CONSOLE_TEXT << "Takeoff failed:" << takeoff_result
                   << NORMAL_CONSOLE_TEXT << std::endl;
         return 1;
     }
@@ -222,8 +220,8 @@ int main(int argc, char **argv)
     std::cout << "Landing..." << std::endl;
     const Action::Result land_result = action->land();
     if (land_result != Action::Result::Success) {
-        std::cout << ERROR_CONSOLE_TEXT << "Land failed:" << Action::result_str(land_result)
-                  << NORMAL_CONSOLE_TEXT << std::endl;
+        std::cout << ERROR_CONSOLE_TEXT << "Land failed:" << land_result << NORMAL_CONSOLE_TEXT
+                  << std::endl;
         return 1;
     }
 

--- a/en/examples/transition_vtol_fixed_wing.md
+++ b/en/examples/transition_vtol_fixed_wing.md
@@ -122,9 +122,9 @@ static constexpr auto ERROR_CONSOLE_TEXT = "\033[31m";
 static constexpr auto TELEMETRY_CONSOLE_TEXT = "\033[34m";
 static constexpr auto NORMAL_CONSOLE_TEXT = "\033[0m";
 
-void usage(const std::string &bin_name);
+void usage(const std::string& bin_name);
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
     if (argc != 2) {
         usage(argv[0]);
@@ -137,9 +137,8 @@ int main(int argc, char **argv)
 
     // Add connection specified by CLI argument.
     const ConnectionResult connection_result = dc.add_any_connection(connection_url);
-    if (connection_result != ConnectionResult::SUCCESS) {
-        std::cout << ERROR_CONSOLE_TEXT
-                  << "Connection failed: " << connection_result_str(connection_result)
+    if (connection_result != ConnectionResult::Success) {
+        std::cout << ERROR_CONSOLE_TEXT << "Connection failed: " << connection_result
                   << NORMAL_CONSOLE_TEXT << std::endl;
         return 1;
     }
@@ -151,21 +150,20 @@ int main(int argc, char **argv)
     }
 
     // Get system and plugins.
-    System &system = dc.system();
+    System& system = dc.system();
     auto telemetry = std::make_shared<Telemetry>(system);
     auto action = std::make_shared<Action>(system);
 
     // We want to listen to the altitude of the drone at 1 Hz.
     const Telemetry::Result set_rate_result = telemetry->set_rate_position(1.0);
-    if (set_rate_result != Telemetry::Result::SUCCESS) {
-        std::cout << ERROR_CONSOLE_TEXT
-                  << "Setting rate failed: " << Telemetry::result_str(set_rate_result)
+    if (set_rate_result != Telemetry::Result::Success) {
+        std::cout << ERROR_CONSOLE_TEXT << "Setting rate failed: " << set_rate_result
                   << NORMAL_CONSOLE_TEXT << std::endl;
         return 1;
     }
 
     // Set up callback to monitor altitude.
-    telemetry->position_async([](Telemetry::Position position) {
+    telemetry->subscribe_position([](Telemetry::Position position) {
         std::cout << TELEMETRY_CONSOLE_TEXT << "Altitude: " << position.relative_altitude_m << " m"
                   << NORMAL_CONSOLE_TEXT << std::endl;
     });
@@ -181,8 +179,8 @@ int main(int argc, char **argv)
     const Action::Result arm_result = action->arm();
 
     if (arm_result != Action::Result::Success) {
-        std::cout << ERROR_CONSOLE_TEXT << "Arming failed: " << Action::result_str(arm_result)
-                  << NORMAL_CONSOLE_TEXT << std::endl;
+        std::cout << ERROR_CONSOLE_TEXT << "Arming failed: " << arm_result << NORMAL_CONSOLE_TEXT
+                  << std::endl;
         return 1;
     }
 
@@ -190,7 +188,7 @@ int main(int argc, char **argv)
     std::cout << "Taking off." << std::endl;
     const Action::Result takeoff_result = action->takeoff();
     if (takeoff_result != Action::Result::Success) {
-        std::cout << ERROR_CONSOLE_TEXT << "Takeoff failed:n" << Action::result_str(takeoff_result)
+        std::cout << ERROR_CONSOLE_TEXT << "Takeoff failed:n" << takeoff_result
                   << NORMAL_CONSOLE_TEXT << std::endl;
         return 1;
     }
@@ -202,8 +200,7 @@ int main(int argc, char **argv)
     const Action::Result fw_result = action->transition_to_fixedwing();
 
     if (fw_result != Action::Result::Success) {
-        std::cout << ERROR_CONSOLE_TEXT
-                  << "Transition to fixed wing failed: " << Action::result_str(fw_result)
+        std::cout << ERROR_CONSOLE_TEXT << "Transition to fixed wing failed: " << fw_result
                   << NORMAL_CONSOLE_TEXT << std::endl;
         return 1;
     }
@@ -216,8 +213,7 @@ int main(int argc, char **argv)
     // We pass latitude and longitude but leave altitude and yaw unset by passing NAN.
     const Action::Result goto_result = action->goto_location(47.3633001, 8.5428515, NAN, NAN);
     if (goto_result != Action::Result::Success) {
-        std::cout << ERROR_CONSOLE_TEXT
-                  << "Goto command failed: " << Action::result_str(goto_result)
+        std::cout << ERROR_CONSOLE_TEXT << "Goto command failed: " << goto_result
                   << NORMAL_CONSOLE_TEXT << std::endl;
         return 1;
     }
@@ -229,8 +225,7 @@ int main(int argc, char **argv)
     std::cout << "Transition back to multicopter..." << std::endl;
     const Action::Result mc_result = action->transition_to_multicopter();
     if (mc_result != Action::Result::Success) {
-        std::cout << ERROR_CONSOLE_TEXT
-                  << "Transition to multi copter failed: " << Action::result_str(mc_result)
+        std::cout << ERROR_CONSOLE_TEXT << "Transition to multi copter failed: " << mc_result
                   << NORMAL_CONSOLE_TEXT << std::endl;
         return 1;
     }
@@ -242,8 +237,8 @@ int main(int argc, char **argv)
     std::cout << "Landing..." << std::endl;
     const Action::Result land_result = action->land();
     if (land_result != Action::Result::Success) {
-        std::cout << ERROR_CONSOLE_TEXT << "Land failed: " << Action::result_str(land_result)
-                  << NORMAL_CONSOLE_TEXT << std::endl;
+        std::cout << ERROR_CONSOLE_TEXT << "Land failed: " << land_result << NORMAL_CONSOLE_TEXT
+                  << std::endl;
         return 1;
     }
 
@@ -258,7 +253,7 @@ int main(int argc, char **argv)
     return 0;
 }
 
-void usage(const std::string &bin_name)
+void usage(const std::string& bin_name)
 {
     std::cout << NORMAL_CONSOLE_TEXT << "Usage : " << bin_name << " <connection_url>" << std::endl
               << "Connection URL format should be :" << std::endl

--- a/en/guide/connections.md
+++ b/en/guide/connections.md
@@ -25,7 +25,7 @@ The code snippet below shows how to set up monitoring with `add_any_connection()
 Mavsdk dc;
 std::string connection_url="udp://0.0.0.0:14540";
 ConnectionResult connection_result = dc.add_any_connection(connection_url);
-ASSERT_EQ(connection_result,ConnectionResult::SUCCESS)
+ASSERT_EQ(connection_result,ConnectionResult::Success)
 ```
 
 > **Note** The connection string used above (`udp://0.0.0.0:14540`) is to the [standard PX4 broadcast UDP port](https://dev.px4.io/master/en/simulation/#default-px4-mavlink-udp-ports) for off-board APIs (14540). This is the normal/most common way for offboard APIs to connect to PX4 over WiFi.

--- a/en/guide/connections.md
+++ b/en/guide/connections.md
@@ -30,10 +30,10 @@ ASSERT_EQ(connection_result,ConnectionResult::SUCCESS)
 
 > **Note** The connection string used above (`udp://0.0.0.0:14540`) is to the [standard PX4 broadcast UDP port](https://dev.px4.io/master/en/simulation/#default-px4-mavlink-udp-ports) for off-board APIs (14540). This is the normal/most common way for offboard APIs to connect to PX4 over WiFi.
 
-The SDK also provides the [connection_result_str()](../api_reference/namespacemavsdk.md#namespacemavsdk_1a59e8a165c1edafab6ab0c04df2c83679) method, which you can use to create a human-readable string for the [ConnectionResult](../api_reference/namespacemavsdk.md#namespacemavsdk_1a0bad93f6d037051ac3906a0bcc09f992).
+The SDK also provides an operator so that you can just print out a human readable string for a [ConnectionResult](../api_reference/namespacemavsdk.md#namespacemavsdk_1a0bad93f6d037051ac3906a0bcc09f992).
 The code fragment below shows how you might print the string for the preceding code fragment to the console:
 ```cpp
-std::cout << "Connection string: " << connection_result_str(connection_result) << std::endl;
+std::cout << "Connection string: " << connection_result << std::endl;
 ```
 
 

--- a/en/guide/connections.md
+++ b/en/guide/connections.md
@@ -1,8 +1,8 @@
 # Connecting to Systems (Vehicles)
 
-The MAVSDK allows you to connect to multiple vehicles attached to the local WiFi network and/or via serial ports. 
+The MAVSDK allows you to connect to multiple vehicles attached to the local WiFi network and/or via serial ports.
 
-In order to detect vehicles you must first specify the communication ports that the SDK will monitor for new systems. 
+In order to detect vehicles you must first specify the communication ports that the SDK will monitor for new systems.
 Once monitoring a port, the SDK will automatically detect connected vehicles, add them to its collection, and notify registered users of connection and disconnection events.
 
 ## Monitoring a Port
@@ -39,10 +39,10 @@ std::cout << "Connection string: " << connection_result << std::endl;
 
 ### Register for System-Detection Notifications
 
-The SDK monitors any added communication ports for new systems, which are distinguished by vehicle [UUID](../api_reference/classmavsdk_1_1_info.md). 
+The SDK monitors any added communication ports for new systems, which are distinguished by vehicle [UUID](../api_reference/classmavsdk_1_1_info.md).
 Clients can register for notification when new systems are discovered using [register_on_discover()](../api_reference/classmavsdk_1_1_mavsdk.md#classmavsdk_1_1_mavsdk_1aa8d55ab10da8f1b868003b44e99c2ecc), and for systems timing out (no longer connected) using [register_on_timeout()](../api_reference/classmavsdk_1_1_mavsdk.md#classmavsdk_1_1_mavsdk_1a4baa7d2dd487e9cff12f5dda11ba3262).
 
-The methods are used in the same way, and invoke a callback function with the UUID of the system that was discovered/disconnected. 
+The methods are used in the same way, and invoke a callback function with the UUID of the system that was discovered/disconnected.
 This UUID can then be used to get a `System` object for managing the associated vehicle (see [Accessing Systems](#accessing-systems) below).
 
 > **Note** If a system does not have a UUID then `Mavsdk` will instead use its MAVLink system ID (a number in the range of 1 to 255).
@@ -60,8 +60,8 @@ dc.register_on_discover([](uint64_t uuid) {
 
 ## Iterating all Systems
 
-You can iterate all system UUIDs that have been detected by `Mavsdk` 
-(since it was started, over all communication ports) using the [system_uuids()](../api_reference/classmavsdk_1_1_mavsdk.md#classmavsdk_1_1_mavsdk_1a80bd9c663d0e03c24f029fd77e914c3c) method. 
+You can iterate all system UUIDs that have been detected by `Mavsdk`
+(since it was started, over all communication ports) using the [system_uuids()](../api_reference/classmavsdk_1_1_mavsdk.md#classmavsdk_1_1_mavsdk_1a80bd9c663d0e03c24f029fd77e914c3c) method.
 This returns a vector of UUID values, from which you can get `System` objects that are used to manage vehicles.
 
 The following code fragment shows how to iterate through the UUIDs (in this case, just printing them to standard `cout`).
@@ -74,7 +74,7 @@ for ( auto i = system_vector.begin(); i != system_vector.end(); i++ ) {
 }
 ```
 
-The vector contains UUIDs for all systems detected by `Mavsdk`, including those that may no longer be connected. 
+The vector contains UUIDs for all systems detected by `Mavsdk`, including those that may no longer be connected.
 You can use [Mavsdk::is_connected(uint64_t)](../api_reference/classmavsdk_1_1_mavsdk.md#classmavsdk_1_1_mavsdk_1aced99aea3a52c1245b1d80ff1f22cbd2) to determine if the system with a particular UUID is connected or not.
 If you're only expecting a single connection, then you can use the parameterless `is_connected()` method.
 
@@ -85,16 +85,16 @@ Once `Mavsdk` has provided you with a vehicle `UUID` you can use the [Mavsdk::sy
 
 ```cpp
 Mavsdk dc;
-//... 
+//...
 //Use UUID named uuid to get the associated System
 System &system = dc.system(uuid);
 ```
 
-> **Tip** If you know that there is only one connected system you can instead call `system()` without any UUID. 
+> **Tip** If you know that there is only one connected system you can instead call `system()` without any UUID.
   This will return the first system detected, or a null `System` if none have been discovered.
 ```
 System &system = dc.system()
 ```
 
-The `System` is used by the MAVSDK plugin classes to query and control the vehicle. 
+The `System` is used by the MAVSDK plugin classes to query and control the vehicle.
 For more information see [Using Plugins](../guide/using_plugins.md) (and the other guide topics).

--- a/en/guide/follow_me.md
+++ b/en/guide/follow_me.md
@@ -55,7 +55,7 @@ The `follow_me` pointer can then used to access the plugin API (as shown in the 
 ## Set the Follow Configuration
 
 By default the vehicle will follow directly behind the target at a height and distance of 8 metres. 
-You can (optionally) call [set_config()](../api_reference/classmavsdk_1_1_follow_me.md#classmavsdk_1_1_follow_me_1a1d7c0e5598769365aeaec8026578a977) at any time to specify a different height, follow distance, relative position (front left/right/centre or behind) and responsiveness to target movements.
+You can (optionally) call [set_config()](../api_reference/classmavsdk_1_1_follow_me.md#classmavsdk_1_1_follow_me_1aa76aab9a21bc3ae475bee6a55c0e4d30) at any time to specify a different height, follow distance, relative position (front left/right/centre or behind) and responsiveness to target movements.
 
 The code fragment below shows how to set the configuration:
 ```cpp
@@ -74,16 +74,16 @@ if (config_result != FollowMe::Result::SUCCESS) {
 }
 ```
 
-The [get_config()](../api_reference/classmavsdk_1_1_follow_me.md#classmavsdk_1_1_follow_me_1a5a39cc685ea4288363ef38ebbd628062) method is provided to get the current configuration:
+The [get_config()](../api_reference/classmavsdk_1_1_follow_me.md#classmavsdk_1_1_follow_me_1aca2e599cd6fb889b9f80dc7a9da57ee9) method is provided to get the current configuration:
 ```cpp
 auto curr_config = follow_me->get_config();
 ```
 
 ## Following a Target
 
-To start and stop following a target, call [start()](../api_reference/classmavsdk_1_1_follow_me.md#classmavsdk_1_1_follow_me_1a54434262fb1351f6ad648879606b6dd7) and [stop()](../api_reference/classmavsdk_1_1_follow_me.md#classmavsdk_1_1_follow_me_1a157c9a6e4047d317fcb54abc71b390e2), respectively - `start()` puts the vehicle into [Follow-Me mode](https://docs.px4.io/master/en/flight_modes/follow_me.html) and `stop()` puts it into [Hold mode](https://docs.px4.io/master/en/flight_modes/hold.html).
+To start and stop following a target, call [start()](../api_reference/classmavsdk_1_1_follow_me.md#classmavsdk_1_1_follow_me_1a4b6ae3ec1ff07d8b3a79038e04992003) and [stop()](../api_reference/classmavsdk_1_1_follow_me.md#classmavsdk_1_1_follow_me_1a202a7b9edf56d9b883c974a09c14ba7d), respectively - `start()` puts the vehicle into [Follow-Me mode](https://docs.px4.io/master/en/flight_modes/follow_me.html) and `stop()` puts it into [Hold mode](https://docs.px4.io/master/en/flight_modes/hold.html).
 
-Use [set_target_location()](../api_reference/classmavsdk_1_1_follow_me.md#classmavsdk_1_1_follow_me_1a8423c855534f821aeb051997c1a576a5) to set the target position(s) for the vehicle to follow (the app typically passes its host's current position, which it would obtain using OS-specific methods). 
+Use [set_target_location()](../api_reference/classmavsdk_1_1_follow_me.md#classmavsdk_1_1_follow_me_1a1a99e282472235f726bfde430873ffd5) to set the target position(s) for the vehicle to follow (the app typically passes its host's current position, which it would obtain using OS-specific methods). 
 This can be called at any time, but messages will only be sent once following is started. 
 The plugin automatically resends the last set position at the rate required by the autopilot/flight mode (1 Hz). 
 
@@ -111,7 +111,7 @@ if (follow_me_result != FollowMe::Result::SUCCESS) {
 }
 ```
 
-The last location that was set can be retrieved using [get_last_location()](../api_reference/classmavsdk_1_1_follow_me.md#classmavsdk_1_1_follow_me_1ae78d10ea8c6a5a27dbc26c421d8ae48f).
+The last location that was set can be retrieved using [get_last_location()](../api_reference/classmavsdk_1_1_follow_me.md#classmavsdk_1_1_follow_me_1af2a1af346ee2fa7761b58b406e9e6e0c).
 Before a target position is first set this API will return `Nan`.
 
 

--- a/en/guide/general_usage.md
+++ b/en/guide/general_usage.md
@@ -24,7 +24,8 @@ MAVSDK APIs do not raise exceptions! Instead, methods that can fail return succe
 > **Tip** The error code usually reflects acknowledgment from the vehicle that it will perform the requested action (or not). 
   The operation itself may not yet have completed (e.g. taking off).
 
-The various classes also all provide methods getting human readable strings from their associated enum (e.g. [connection_result_str()](../api_reference/namespacemavsdk.md#namespacemavsdk_1a59e8a165c1edafab6ab0c04df2c83679), [Telemetry::result_str()](../api_reference/classmavsdk_1_1_telemetry.md#classmavsdk_1_1_telemetry_1a20bff42d7bb42c002ef7217cf98990e8)). You can see how these are used in the example code.
+The various classes also all provide operators for getting human readable strings from their associated result enum.
+You can see how these are used in the example code.
 
 
 ## Shared Vehicle Control
@@ -32,7 +33,7 @@ The various classes also all provide methods getting human readable strings from
 A vehicle can receive commands from multiple sources, including a Ground Control Station, or other MAVLink applications.
 
 SDK applications, which are running in environments where it is possible, can explicitly monitor for changes in flight mode 
-(outside application control) and change behaviour appropriately (e.g. using [Telemetry::flight_mode_async()](../api_reference/classmavsdk_1_1_telemetry.md#classmavsdk_1_1_telemetry_1adede4202304e53466b4df41367a75878)). 
+(outside application control) and change behaviour appropriately (e.g. using [Telemetry::subscribe_flight_mode()](../api_reference/classmavsdk_1_1_telemetry.md#classmavsdk_1_1_telemetry_1a53db5fb36bf10fbc7ac004a3be9100a4)). 
 
 
 ## API Limitations/Behaviour

--- a/en/guide/missions.md
+++ b/en/guide/missions.md
@@ -77,11 +77,12 @@ std::vector<std::shared_ptr<MissionItem>> mission_items;
 ```
 
 You can create as many `MissionItem` objects as you like and use `std_vector::push_back()` to add them to the back of the mission item vector. 
-The example below shows how to create and add a `MissionItem`, that just sets the target position (using [set_position()](../api_reference/structmavsdk_1_1_mission_1_1_mission_item.md#classmavsdk_1_1_mission_item_1abe17a24cf27fa0b6d632f39f8d7d15f3)).
+The example below shows how to create and add a `MissionItem` that sets the target position (using [set_position()](../api_reference/structmavsdk_1_1_mission_1_1_mission_item.md#classmavsdk_1_1_mission_item_1abe17a24cf27fa0b6d632f39f8d7d15f3)).
 ```cpp
 // Create MissionItem and set its position
 std::shared_ptr<MissionItem> new_item(new MissionItem());
-new_item->set_position(47.40 /*latitude_deg*/, 8.5455360114574432 /*longitude_deg*/);
+new_item->latitude_deg = 47.40;
+new_item->longitude_deg = 8.5455360114574432;
 
 // Add new_item to the vector
 mission_items.push_back(new_item);
@@ -91,13 +92,18 @@ The example below shows how you might set the other options on a second `Mission
 
 ```cpp
 std::shared_ptr<MissionItem> new_item2(new MissionItem());
-new_item2->set_position(47.50 /*latitude_deg*/, 8.5455360114574432 /*longitude_deg*/);
-new_item2->set_relative_altitude(2.0f);
-new_item2->set_speed(5.0f /* m/s */);
-new_item2->set_fly_through(true);
-new_item2->set_gimbal_pitch_and_yaw(20.0f /*pitch*/, 60.0f /*yaw degrees*/);
-new_item2->set_camera_action(MissionItem::CameraAction::TAKE_PHOTO);
-    
+new_item2->latitude_deg = 47.40;
+new_item2->longitude_deg = 8.5455360114574432);
+new_item2->relative_altitude_m = 2.0f;
+new_item2->speed_m_s = 5.0f;
+new_item2->is_fly_through = true;
+new_item2->gimbal_pitch_deg = 20.0f;
+new_item2->gimbal_pitch_deg = 20.0f;
+new_item2->gimbal_yaw_deg = 60.0f;
+new_item2->camera_action = MissionItem::CameraAction::TakePhoto;
+new_item2->loiter_time_s = 1.0f;
+new_item2->camera_photo_interval_s =  1.0f;
+	
 //Add new_item2 to the vector
 mission_items.push_back(new_item2);
 ```
@@ -119,24 +125,15 @@ Using this approach you have to specify every attribute for every mission item, 
 The definition and use of this function is shown below:
 
 ```cpp
-std::shared_ptr<MissionItem> make_mission_item(double latitude_deg,
-                                               double longitude_deg,
-                                               float relative_altitude_m,
-                                               float speed_m_s,
-                                               bool is_fly_through,
-                                               float gimbal_pitch_deg,
-                                               float gimbal_yaw_deg,
-                                               MissionItem::CameraAction camera_action)
-{
-    std::shared_ptr<MissionItem> new_item(new MissionItem());
-    new_item->set_position(latitude_deg, longitude_deg);
-    new_item->set_relative_altitude(relative_altitude_m);
-    new_item->set_speed(speed_m_s);
-    new_item->set_fly_through(is_fly_through);
-    new_item->set_gimbal_pitch_and_yaw(gimbal_pitch_deg, gimbal_yaw_deg);
-    new_item->set_camera_action(camera_action);
-    return new_item;
-}
+static Mission::MissionItem make_mission_item(
+    double latitude_deg,
+    double longitude_deg,
+    float relative_altitude_m,
+    float speed_m_s,
+    bool is_fly_through,
+    float gimbal_pitch_deg,
+    float gimbal_yaw_deg,
+    Mission::MissionItem::CameraAction camera_action);
 
 
 mission_items.push_back(
@@ -153,7 +150,7 @@ mission_items.push_back(
 
 > **Note** To export a mission plan from the *QGroundControl* use the [Sync Tool](https://docs.qgroundcontrol.com/en/PlanView/PlanView.html#file) (**Plan View > Sync Tool**, and then select **Save to File**).
 
-The mission is imported using the static [import_qgroundcontrol_mission](../api_reference/classmavsdk_1_1_mission.md#classmavsdk_1_1_mission_1aa0a937d18e9ce2c4f346aa9ee8a1a6d9) method.
+The mission is imported using the static [import_qgroundcontrol_mission](../api_reference/classmavsdk_1_1_mission.md#classmavsdk_1_1_mission_1a575a720f5814dd0380220abaf7a955f5) method.
 The method will fail with an error if the plan file cannot be found, cannot be parsed, or if it contains mission items that are [not supported](#supported_mission_commands).
 
 The code fragment below shows how to import mission items from a plan:
@@ -170,7 +167,7 @@ The mission (`mission_items`) can then be uploaded as shown in the section [Uplo
 
 ## Uploading a Mission {#uploading_mission}
 
-Use [Mission::upload_mission_async()](../api_reference/classmavsdk_1_1_mission.md#classmavsdk_1_1_mission_1ad6117cf541865249900201fe6305f5a1) to upload the mission defined in the previous section.
+Use [Mission::upload_mission()](../api_reference/classmavsdk_1_1_mission.md#classmavsdk_1_1_mission_1a38274b1c1509375a182c44711ee9f7b1) to upload the mission defined in the previous section.
 
 The example below shows how this is done, using promises to wait on the result.
 
@@ -178,16 +175,19 @@ The example below shows how this is done, using promises to wait on the result.
 // ... declare and populate the mission vector: mission_items
 
 {
+    std::cout << "Uploading mission..." << std::endl;
+    // We only have the upload_mission function asynchronous for now, so we wrap it using
+    // std::future.
     auto prom = std::make_shared<std::promise<Mission::Result>>();
     auto future_result = prom->get_future();
+    Mission::MissionPlan mission_plan{};
+    mission_plan.mission_items = mission_items;
     mission->upload_mission_async(
-    mission_items, [prom](Mission::Result result) {
-        prom->set_value(result);
-    });
+        mission_plan, [prom](Mission::Result result) { prom->set_value(result); });
 
     const Mission::Result result = future_result.get();
-    if (result != Mission::Result::SUCCESS) {
-        std::cout << "Mission upload failed (" << Mission::result_str(result) << "), exiting." << std::endl;
+    if (result != Mission::Result::Success) {
+        std::cout << "Mission upload failed (" << result << "), exiting." << std::endl;
         return 1;
     }
     std::cout << "Mission uploaded." << std::endl;
@@ -196,7 +196,7 @@ The example below shows how this is done, using promises to wait on the result.
 
 ## Starting/Pausing Missions 
 
-Start or resume a paused mission using [Mission::start_mission_async()](../api_reference/classmavsdk_1_1_mission.md#classmavsdk_1_1_mission_1af0a6404b7af085759bc6dad518eea525).
+Start or resume a paused mission using [Mission::start_mission_async()](../api_reference/classmavsdk_1_1_mission.md#classmavsdk_1_1_mission_1a31ca2fc6b9fe4802dbc3fbebad0bb5d7).
 The vehicle must already have a mission (the mission need not have been uploaded using the SDK).
 
 The code fragment below shows how this is done, using promises to wait on the result.
@@ -219,7 +219,7 @@ The code fragment below shows how this is done, using promises to wait on the re
 }
 ```
 
-To pause a mission use [Mission::pause_mission_async()](../api_reference/classmavsdk_1_1_mission.md#classmavsdk_1_1_mission_1a39a0434bb2e731ccca7c0f2d579b0ee8). 
+To pause a mission use [Mission::pause_mission_async()](../api_reference/classmavsdk_1_1_mission.md#classmavsdk_1_1_mission_1a4c5679369e215ef21901fc7ffe1ce32b). 
 The code is almost exactly the same as for starting a mission:
 
 ```cpp
@@ -244,25 +244,22 @@ The code is almost exactly the same as for starting a mission:
 
 ## Monitoring Progress
 
-Asynchronously monitor progress using [Mission::subscribe_progress()](../api_reference/classmavsdk_1_1_mission.md#classmavsdk_1_1_mission_1aa882278b493a2390ca0b3cf7027b3a01), 
+Asynchronously monitor progress using [Mission::subscribe_mission_progress()](../api_reference/classmavsdk_1_1_mission.md#classmavsdk_1_1_mission_1a6dd32b92e593c1a692fe59e5bfb670fb), 
 which receives a regular callback with the current `MissionItem` number and the total number of items.
 
 The code fragment just takes a lambda function that reports the current status. 
 
 ```cpp
-mission->subscribe_progress( [](int current, int total) {
-       std::cout << "Mission status update: " << current << " / " << total << std::endl;
+mission->subscribe_mission_progress( [](Mission::MissionProgress mission_progress)) {
+       std::cout << "Mission status update: " << mission_progress.current << " / " << mission_progress.total << std::endl;
     });
 ```
 
 > **Note** The mission is complete when `current == total`.
 
-The following synchronous methods are also available for checking mission progress:
-* [mission_finished()](../api_reference/classmavsdk_1_1_mission.md#classmavsdk_1_1_mission_1a5861a4c6325ca1eeb1cc1d37004a7f61) - Checks if mission has been finished.
-* [current_mission_item()](../api_reference/classmavsdk_1_1_mission.md#classmavsdk_1_1_mission_1a25afa022a4206bd1055a692937f9b916) - Returns the current mission item index.
-* [total_mission_items()](../api_reference/classmavsdk_1_1_mission.md#classmavsdk_1_1_mission_1a97c07cbcf5e9c54d5776cd86e4228311) - Gets the total number of items.
+The following synchronous methods is also available for checking mission progress:
+* [is_mission_finished()](../api_reference/classmavsdk_1_1_mission.md#classmavsdk_1_1_mission_1a1ecf4f8798ab9ae96882dfbd34f23466) - Checks if mission has been finished.
 
-> **Note** The mission is (also) complete when `current_mission_item()` == `total_mission_items()`.
 
 
 ## Taking Off, Landing, Returning
@@ -277,7 +274,7 @@ If required you can instead use the appropriate commands in the [Action](../guid
 
 ## Downloading Missions
 
-Use [Mission::download_mission_async()](../api_reference/classmavsdk_1_1_mission.md#classmavsdk_1_1_mission_1a23173385eef570b9802402fc047104c1) to download a mission from the vehicle.
+Use [Mission::download_mission_async()](../api_reference/classmavsdk_1_1_mission.md#classmavsdk_1_1_mission_1a04e7e7074273b4591a820894c5c4ad43) to download a mission from the vehicle.
 The mission is downloaded as a vector of [MissionItem](../api_reference/structmavsdk_1_1_mission_1_1_mission_item.md) objects, that you can then view or manipulate as required.
 
 > **Note** Mission download will fail if the mission contains a command that is outside the [supported set](#supported_mission_commands). 

--- a/en/guide/missions.md
+++ b/en/guide/missions.md
@@ -77,7 +77,7 @@ std::vector<std::shared_ptr<MissionItem>> mission_items;
 ```
 
 You can create as many `MissionItem` objects as you like and use `std_vector::push_back()` to add them to the back of the mission item vector. 
-The example below shows how to create and add a `MissionItem` that sets the target position (using [set_position()](../api_reference/structmavsdk_1_1_mission_1_1_mission_item.md#classmavsdk_1_1_mission_item_1abe17a24cf27fa0b6d632f39f8d7d15f3)).
+The example below shows how to create and add a `MissionItem` that sets the target position.
 ```cpp
 // Create MissionItem and set its position
 std::shared_ptr<MissionItem> new_item(new MissionItem());
@@ -318,6 +318,7 @@ The code fragment below shows how to download a mission:
 ```
 
 
+
 ## Further Information
 
 * [Mission Flight Mode](https://docs.px4.io/master/en/flight_modes/mission.html) (PX4 User Guide)
@@ -325,7 +326,10 @@ The code fragment below shows how to download a mission:
 * [Example:Fly QGC Plan Mission](../examples/fly_mission_qgc_plan.md)
 * Integration tests:
   * [mission.cpp](https://github.com/mavlink/MAVSDK/blob/{{ book.github_branch }}/src/integration_tests/mission.cpp)
+  * [mission_cancellation.cpp](https://github.com/mavlink/MAVSDK/blob/{{ book.github_branch }}/src/integration_tests/mission_cancellation.cpp)
   * [mission_change_speed.cpp](https://github.com/mavlink/MAVSDK/blob/{{ book.github_branch }}/src/integration_tests/mission_change_speed.cpp)
-  * [mission_survey.cpp](https://github.com/mavlink/MAVSDK/blob/{{ book.github_branch }}/src/integration_tests/mission_survey.cpp)
+  * [mission_raw_mission_changed.cpp](https://github.com/mavlink/MAVSDK/blob/{{ book.github_branch }}/src/integration_tests/mission_raw_mission_changed.cpp)  
+  * [mission_rtl.cpp](https://github.com/mavlink/MAVSDK/blob/{{ book.github_branch }}/src/integration_tests/mission_rtl.cpp)
+  * [mission_transfer_lossy.cpp](https://github.com/mavlink/MAVSDK/blob/{{ book.github_branch }}/src/integration_tests/mission_transfer_lossy.cpp)  
 * Unit Tests:
   * [mission_import_qgc_test.cpp](https://github.com/mavlink/MAVSDK/blob/{{ book.github_branch }}/src/plugins/mission/mission_import_qgc_test.cpp)

--- a/en/guide/missions.md
+++ b/en/guide/missions.md
@@ -4,12 +4,12 @@ The Mission API (plugin) allows you to create, upload, download, import from *QG
 Missions can have multiple "mission items", each which may specify a position, altitude, fly-through behaviour, camera action, gimbal position, and the speed to use when traveling to the next position.
 
 Missions are *managed* though the [Mission](../api_reference/classmavsdk_1_1_mission.md) class, which communicates with the vehicle to upload mission information and run, pause, track the mission progress etc. 
-The mission that is uploaded to the vehicle is defined as a vector of [MissionItem](../api_reference/classmavsdk_1_1_mission_item.md) objects.
+The mission that is uploaded to the vehicle is defined as a vector of [MissionItem](../api_reference/structmavsdk_1_1_mission_1_1_mission_item.md) objects.
 
 
 ## Supported Mission Commands {#supported_mission_commands}
 
-The [MissionItem](../api_reference/classmavsdk_1_1_mission_item.md) class abstracts a small but useful subset of the mission commands supported by PX4 (and the MAVLink specification):
+The [MissionItem](../api_reference/structmavsdk_1_1_mission_1_1_mission_item.md) class abstracts a small but useful subset of the mission commands supported by PX4 (and the MAVLink specification):
 
 The supported set is:
 * [MAV_CMD_NAV_WAYPOINT](https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_WAYPOINT)
@@ -71,13 +71,13 @@ The `mission` pointer can then used to access the plugin API (as shown in the fo
 
 ## Defining a Mission
 
-A mission must be defined as a vector of [MissionItem](../api_reference/classmavsdk_1_1_mission_item.md) objects as shown below:
+A mission must be defined as a vector of [MissionItem](../api_reference/structmavsdk_1_1_mission_1_1_mission_item.md) objects as shown below:
 ```cpp
 std::vector<std::shared_ptr<MissionItem>> mission_items;
 ```
 
 You can create as many `MissionItem` objects as you like and use `std_vector::push_back()` to add them to the back of the mission item vector. 
-The example below shows how to create and add a `MissionItem`, that just sets the target position (using [set_position()](../api_reference/classmavsdk_1_1_mission_item.md#classmavsdk_1_1_mission_item_1abe17a24cf27fa0b6d632f39f8d7d15f3)).
+The example below shows how to create and add a `MissionItem`, that just sets the target position (using [set_position()](../api_reference/structmavsdk_1_1_mission_1_1_mission_item.md#classmavsdk_1_1_mission_item_1abe17a24cf27fa0b6d632f39f8d7d15f3)).
 ```cpp
 // Create MissionItem and set its position
 std::shared_ptr<MissionItem> new_item(new MissionItem());
@@ -278,7 +278,7 @@ If required you can instead use the appropriate commands in the [Action](../guid
 ## Downloading Missions
 
 Use [Mission::download_mission_async()](../api_reference/classmavsdk_1_1_mission.md#classmavsdk_1_1_mission_1a23173385eef570b9802402fc047104c1) to download a mission from the vehicle.
-The mission is downloaded as a vector of [MissionItem](../api_reference/classmavsdk_1_1_mission_item.md) objects, that you can then view or manipulate as required.
+The mission is downloaded as a vector of [MissionItem](../api_reference/structmavsdk_1_1_mission_1_1_mission_item.md) objects, that you can then view or manipulate as required.
 
 > **Note** Mission download will fail if the mission contains a command that is outside the [supported set](#supported_mission_commands). 
 > Missions created using *QGroundControl* are not guaranteed to successfully download! 

--- a/en/guide/offboard.md
+++ b/en/guide/offboard.md
@@ -62,9 +62,8 @@ offboard->set_velocity_body({0.0f, 0.0f, 0.0f, 0.0f});
 
 // Start offboard mode.
 Offboard::Result offboard_result = offboard->start();
-if (result != Offboard::Result::SUCCESS) {
-        std::cerr << "Offboard::start() failed: "
-        << Offboard::result_str(offboard_result) << std::endl;
+if (result != Offboard::Result::Success) {
+        std::cerr << "Offboard::start() failed: " << offboard_result << std::endl;
     }
 ```
 
@@ -73,16 +72,15 @@ Above we use the synchronous API, and then use [Offboard::result_str()](../api_r
 
 You can change the setpoints as needed (new setpoints replace any old setpoints).
 
-To stop offboard mode call [Offboard::stop()](../api_reference/classmavsdk_1_1_offboard.md#classmavsdk_1_1_offboard_1a9a54e588bcfd5b0ffca27833ad4f6b10) or [stop_async()](../api_reference/classmavsdk_1_1_offboard.md#classmavsdk_1_1_offboard_1a8d52d710dbfcd77a33d8657ea55ab606).
+To stop offboard mode call [Offboard::stop()](../api_reference/classmavsdk_1_1_offboard.md#classmavsdk_1_1_offboard_1a626810cbfa02b36019dde2d2fd4c3da9) or [stop_async()](../api_reference/classmavsdk_1_1_offboard.md#classmavsdk_1_1_offboard_1a86c163d7fa1217b4e82a03daf52065c3).
 The SDK will then clear the current setpoint and put the vehicle into [Hold flight mode](https://docs.px4.io/master/en/flight_modes/hold.html).
 The synchronous API is used as shown below:
 
 ```cpp
 //Stop offboard mode
 offboard_result = offboard->stop();
-if (result != Offboard::Result::SUCCESS) {
-        std::cerr << "Offboard::stop() failed: "
-        << Offboard::result_str(offboard_result) << std::endl;
+if (result != Offboard::Result::Success) {
+        std::cerr << "Offboard::stop() failed: " << offboard_result << std::endl;
     }
 ```
 

--- a/en/guide/offboard.md
+++ b/en/guide/offboard.md
@@ -68,7 +68,7 @@ if (result != Offboard::Result::Success) {
 ```
 
 The methods return/complete with a [Result](../api_reference/classmavsdk_1_1_offboard.md#classmavsdk_1_1_offboard_1a2d4d594301d8c756429457b0982130e9) indicating whether the command was successful.
-Above we use the synchronous API, and then use [Offboard::result_str()](../api_reference/classmavsdk_1_1_offboard.md#classmavsdk_1_1_offboard_1a3402d7e3dc8b4ff15598dfd67af0644b) to get a human readable string for the returned enum.
+Above we use the synchronous API, and then print a human readable string for the returned enum.
 
 You can change the setpoints as needed (new setpoints replace any old setpoints).
 

--- a/en/guide/offboard.md
+++ b/en/guide/offboard.md
@@ -51,10 +51,10 @@ The `offboard` pointer can then used to access the plugin API (as shown in the f
 
 ## Starting/Stopping Offboard Mode
 
-To use offboard mode you must first create a setpoint using any of the setpoint setter methods (e.g. [set_velocity_ned()](../api_reference/classmavsdk_1_1_offboard.md#classmavsdk_1_1_offboard_1a689fec126f8da55dadfc13e67bf9bb39) or [set_velocity_body()](../api_reference/classmavsdk_1_1_offboard.md#classmavsdk_1_1_offboard_1aab32b36b4396cecbac9c745507b2fb81)).
+To use offboard mode you must first create a setpoint using any of the setpoint setter methods (e.g. [set_velocity_ned()](../api_reference/classmavsdk_1_1_offboard.md#classmavsdk_1_1_offboard_1a4edbc6e4528ff955d4e46e7c4e711732) or [set_velocity_body()](../api_reference/classmavsdk_1_1_offboard.md#classmavsdk_1_1_offboard_1abe7364f0a48dda4df34c5c67d177cfb4)).
 You can use any setpoint you like - the vehicle will start acting on the current setpoint as soon as the mode starts.
 
-After you have created a setpoint call [start()](../api_reference/classmavsdk_1_1_offboard.md#classmavsdk_1_1_offboard_1a3f0b71195ae6cb445237b192e3b8343f) or [start_async()](../api_reference/classmavsdk_1_1_offboard.md#classmavsdk_1_1_offboard_1a8d52d710dbfcd77a33d8657ea55ab606) to switch to offboard mode.
+After you have created a setpoint call [start()](../api_reference/classmavsdk_1_1_offboard.md#classmavsdk_1_1_offboard_1ab71d0dd2a81f76e3a0330b0304daa30b) or [start_async()](../api_reference/classmavsdk_1_1_offboard.md#classmavsdk_1_1_offboard_1a0c880ad3f663142e194dd6f187cfc934) to switch to offboard mode.
 
 ```cpp
 // Create a setpoint before starting offboard mode (in this case a null setpoint)
@@ -217,7 +217,7 @@ The vehicle may change out of offboard mode outside the control of your applicat
 In this case, the SDK will automatically stop sending setpoints and [Offboard::is_active()](../api_reference/classmavsdk_1_1_offboard.md#classmavsdk_1_1_offboard_1aa5e0f3c02a03f2667f82d5e162221ff5) will change from `true` to `false`.
 
 Calls to change the setpoint do not return an error!
-Depending on the particular use case, offboard code may need to explicitly monitor for flight mode and change behaviour appropriately (e.g. using [Telemetry::flight_mode_async()](../api_reference/classmavsdk_1_1_telemetry.md#classmavsdk_1_1_telemetry_1adede4202304e53466b4df41367a75878)).
+Depending on the particular use case, offboard code may need to explicitly monitor for flight mode and change behaviour appropriately (e.g. using [Telemetry::subscribe_flight_mode()](../api_reference/classmavsdk_1_1_telemetry.md#classmavsdk_1_1_telemetry_1a53db5fb36bf10fbc7ac004a3be9100a4)).
 
 
 ## Further Information

--- a/en/guide/offboard.md
+++ b/en/guide/offboard.md
@@ -104,7 +104,7 @@ The following sections provide some common usage examples.
 
 The `set_velocity_ned()` can be used to move towards any particular compass direction - e.g. North, West, South-East, etc.
 
-Calling `set_velocity_ned()` using an initialiser list type declaration for the [VelocityNEDYaw](../api_reference/structmavsdk_1_1_offboard_1_1_velocity_n_e_d_yaw.md) argument,
+Calling `set_velocity_ned()` using an initialiser list type declaration for the [VelocityNEDYaw](../api_reference/structmavsdk_1_1_offboard_1_1_velocity_ned_yaw.md) argument,
 the first three values are the velocity components in North, East, and Down directions (in metres/second).
 
 Examples:

--- a/en/guide/taking_off_landing.md
+++ b/en/guide/taking_off_landing.md
@@ -52,7 +52,7 @@ The `action` pointer can then used to access the plugin API (as shown in the fol
 
 ## Taking Off
 
-The recommended way to take off using the SDK (and PX4) is to use either of the [takeoff()](../api_reference/classmavsdk_1_1_action.md#classmavsdk_1_1_action_1a0121d39baf922b1d88283230207ab5d0) or [takeoff_async()](../api_reference/classmavsdk_1_1_action.md#classmavsdk_1_1_action_1a05325bd5c29aa533b95c344e25aa47dd) methods. If a takeoff command is accepted the vehicle will change to the [Takeoff mode](https://docs.px4.io/master/en/flight_modes/takeoff.html), fly to the takeoff altitude, and then hover (in takeoff mode) until another instruction is received.
+The recommended way to take off using the SDK (and PX4) is to use either of the [takeoff()](../api_reference/classmavsdk_1_1_action.md#classmavsdk_1_1_action_1a0121d39baf922b1d88283230207ab5d0) or [takeoff_async()](../api_reference/classmavsdk_1_1_action.md#classmavsdk_1_1_action_1ab658d938970326db41709d83e02b41e6) methods. If a takeoff command is accepted the vehicle will change to the [Takeoff mode](https://docs.px4.io/master/en/flight_modes/takeoff.html), fly to the takeoff altitude, and then hover (in takeoff mode) until another instruction is received.
 
 > **Note** PX4/SDK also provides other ways to take off:
 > - A copter or VTOL will take off automatically if a mission is started (fixed-wing will not). 
@@ -74,7 +74,7 @@ while (telemetry->health_all_ok() != true) {
 ```
 
 The code fragment below performs the same task, but additionally exits the app if calibration is required reports what conditions are still required before the vehicle is "healthy":
-
+<!-- update for subscribe_health_all_ok -->
 ```cpp
 // Exit if calibration is required
 Telemetry::Health check_health = telemetry->health();
@@ -117,7 +117,7 @@ while (telemetry->health_all_ok() != true) {
 }
 ```
 
-> **Note** Vehicle health can also be checked using [Telemetry:health_all_ok_async()](../api_reference/classmavsdk_1_1_telemetry.md#classmavsdk_1_1_telemetry_1ae1a2f05a126a88b19e78078ef5f552f4). 
+> **Note** Vehicle health can also be checked using [Telemetry:subscribe_health_all_ok()](../api_reference/classmavsdk_1_1_telemetry.md#classmavsdk_1_1_telemetry_1a0f94ea6d707ff314e412367d6681bd8f). 
 
 
 ### Arming
@@ -182,7 +182,7 @@ while (current_position<target_alt) {
 
 ## Landing
 
-The best way to land the vehicle at the current location is to use the [land()](../api_reference/classmavsdk_1_1_action.md#classmavsdk_1_1_action_1af6429e1bdb2875deebfe98ed53da3d41) or [land_async()](../api_reference/classmavsdk_1_1_action.md#classmavsdk_1_1_action_1a386b5425dea3449bfd6e20e58a06ab99) methods.
+The best way to land the vehicle at the current location is to use the [land()](../api_reference/classmavsdk_1_1_action.md#classmavsdk_1_1_action_1af6429e1bdb2875deebfe98ed53da3d41) or [land_async()](../api_reference/classmavsdk_1_1_action.md#classmavsdk_1_1_action_1a89d146a766d49f1c706c66a3e2b9252d) methods.
 If the command is accepted the vehicle will change to the [Land mode](https://docs.px4.io/master/en/flight_modes/land.html) and land at the current point.
 
 > **Note** The SDK does not at time of writing recommend other approaches for landing: land mission items are not supported and manually landing the vehicle using the offboard is not as safe. 
@@ -211,7 +211,7 @@ std::cout << "Disarmed, exiting." << std::endl;
 ## Return/RTL
 
 [Return mode](https://docs.px4.io/master/en/flight_modes/return.html) (also known as "Return to Launch", "Return to Land", "Return to Home") flies the vehicle back to the home position and may also land the vehicle (depending on vehicle configuration). 
-This mode is invoked from `Action` using the [return_to_launch()](../api_reference/classmavsdk_1_1_action.md#classmavsdk_1_1_action_1afd7c225df0495b0947f00e7d2dd64877) or [return_to_launch_async()](../api_reference/classmavsdk_1_1_action.md#classmavsdk_1_1_action_1a3b3d5dc86e0d177280b89ec021b94803) methods. 
+This mode is invoked from `Action` using the [return_to_launch()](../api_reference/classmavsdk_1_1_action.md#classmavsdk_1_1_action_1afd7c225df0495b0947f00e7d2dd64877) or [return_to_launch_async()](../api_reference/classmavsdk_1_1_action.md#classmavsdk_1_1_action_1afd7c225df0495b0947f00e7d2dd64877) methods. 
 
 The code below shows how to use the synchronous method:
 
@@ -230,8 +230,8 @@ Depending on the vehicle it may land or hover around the return point. For vehic
 Use the disarm or kill methods to stop the drone motors (the difference is that disarming will only succeed if the drone considers itself landed, while kill will disarm a vehicle even in flight).
 
 The methods are listed below. These are used in the same way as other similar `Action` APIs:
-- [disarm()](../api_reference/classmavsdk_1_1_action.md#classmavsdk_1_1_action_1a44c61110965bcdd3dfb90a08d3c6b6b9), [disarm_async](../api_reference/classmavsdk_1_1_action.md#classmavsdk_1_1_action_1a56b39e81fec142ac0ce7abe6b6313a80)
-- [kill()](../api_reference/classmavsdk_1_1_action.md#classmavsdk_1_1_action_1af40fc1ddf588b3796134a9303ebc3667), [kill_async](../api_reference/classmavsdk_1_1_action.md#classmavsdk_1_1_action_1a1a6d69c174df758b6f06a45e429265db)
+- [disarm()](../api_reference/classmavsdk_1_1_action.md#classmavsdk_1_1_action_1a44c61110965bcdd3dfb90a08d3c6b6b9), [disarm_async](../api_reference/classmavsdk_1_1_action.md#classmavsdk_1_1_action_1a3107f7f5a2f4a478024667f187f8f2aa)
+- [kill()](../api_reference/classmavsdk_1_1_action.md#classmavsdk_1_1_action_1af40fc1ddf588b3796134a9303ebc3667), [kill_async](../api_reference/classmavsdk_1_1_action.md#classmavsdk_1_1_action_1a78c1f15c3b190ba94793045621819e69)
 
 
 > **Tip** PX4 will automatically disarm the vehicle after landing. The disarm methods explicitly invoke the same functionality.
@@ -252,7 +252,7 @@ You can get/set the normal horizontal velocity used in *Return mode*, *Hold mode
 
 `Action` provides methods to transition between VTOL fixed wing and multicopter modes, with both synchronous and asynchronous versions:
 * [transition_to_fixedwing()](../api_reference/classmavsdk_1_1_action.md#classmavsdk_1_1_action_1a8d5cf999a48ea3859ec75db27cf4fbda), [transition_to_multicopter()](../api_reference/classmavsdk_1_1_action.md#classmavsdk_1_1_action_1aac94bfb8613a8e9869e3620b3dc9bb8e)
-* [transition_to_fixedwing_async()](../api_reference/classmavsdk_1_1_action.md#classmavsdk_1_1_action_1ace04a08fdcdd171bc27a86f5f33daeef), [transition_to_multicopter_async()](../api_reference/classmavsdk_1_1_action.md#classmavsdk_1_1_action_1afc5b0e0502685c0a894cbb8445828e8c)
+* [transition_to_fixedwing_async()](../api_reference/classmavsdk_1_1_action.md#classmavsdk_1_1_action_1aa56181441cd64e092a8fb91a38c7c9fd), [transition_to_multicopter_async()](../api_reference/classmavsdk_1_1_action.md#classmavsdk_1_1_action_1a8c109076641b5c9aa6dd78ea8b913529)
 
 The associated action will only be executed for VTOL vehicles (on other vehicle types the command will fail with a `Result` of `VTOL_TRANSITION_SUPPORT_UNKNOWN` or `NO_VTOL_TRANSITION_SUPPORT`). 
 The command will succeed if called when the vehicle is already in the mode.

--- a/en/guide/telemetry.md
+++ b/en/guide/telemetry.md
@@ -133,7 +133,7 @@ These methods are non-blocking; they take a callback function argument and retur
 The callback will be invoked with a populated `struct` of the associated type as soon as an update message arrives from the vehicle. 
 The rate at which this occurs can be set through the API [as discussed above](#update-rate). 
 
-For example, the [Telemetry::subscribe_position()](../api_reference/classmavsdk_1_1_telemetry.md#classmavsdk_1_1_telemetry_1a61bda57b3ca47000ea7e4758b2a33134) has the following prototype, where `callback` is called with a populated [PositionCallback](../api_reference/structmavsdk_1_1_telemetry_1_1_position.md#classmavsdk_1_1_telemetry_1a978b371d636226e198995462afa63552) function:
+For example, the [Telemetry::subscribe_position()](../api_reference/classmavsdk_1_1_telemetry.md#classmavsdk_1_1_telemetry_1a61bda57b3ca47000ea7e4758b2a33134) has the following prototype, where `callback` is called with a populated [PositionCallback](../api_reference/classmavsdk_1_1_telemetry.md#classmavsdk_1_1_telemetry_1a978b371d636226e198995462afa63552) function:
 ```cpp
 void mavsdk::Telemetry::subscribe_position(PositionCallback callback)
 ```

--- a/en/guide/telemetry.md
+++ b/en/guide/telemetry.md
@@ -10,13 +10,31 @@ All the methods of a particular type (synchronous, asynchronous, and set_rate me
 
 The `Telemetry` API provides methods to return the following types of information:
 
-* [Position](../api_reference/structmavsdk_1_1_telemetry_1_1_position.md) - latitude and longitude in degrees, and altitude relative to sea level and to the takeoff altitude.
+* [AccelerationFrd](../api_reference/structmavsdk_1_1_telemetry_1_1_acceleration_frd.md)
+* [ActuatorControlTarget](../api_reference/structmavsdk_1_1_telemetry_1_1_actuator_control_target.md)
+* [ActuatorOutputStatus](../api_reference/structmavsdk_1_1_telemetry_1_1_actuator_output_status.md)
+* [AngularVelocityBody](../api_reference/structmavsdk_1_1_telemetry_1_1_angular_velocity_body.md)
+* [AngularVelocityNed](../api_reference/structmavsdk_1_1_telemetry_1_1_angular_velocity_frd.md)
 * [Battery](../api_reference/structmavsdk_1_1_telemetry_1_1_battery.md) - voltage and percentage power remaining.
-* [GroundSpeedNED](../api_reference/structmavsdk_1_1_telemetry_1_1_ground_speed_n_e_d.md) - velocity components in NED coordinates.
-* Vehicle attitude/orientation - as a [Quaternion](../api_reference/structmavsdk_1_1_telemetry_1_1_quaternion.md) or [EulerAngle](../api_reference/structmavsdk_1_1_telemetry_1_1_euler_angle.md)
-* [GPSInfo](../api_reference/structmavsdk_1_1_telemetry_1_1_g_p_s_info.md) - type of fix, if any, and number of satellites.
+* [Covariance](../api_reference/structmavsdk_1_1_telemetry_1_1_covariance.md)
+* [EulerAngle](../api_reference/structmavsdk_1_1_telemetry_1_1_euler_angle.md) - vehicle attitude/orientation as Euler Angle
+* [FixedwingMetrics](../api_reference/structmavsdk_1_1_telemetry_1_1_fixedwing_metrics.md)
+* [GpsInfo](../api_reference/structmavsdk_1_1_telemetry_1_1_gps_info.md) - type of fix, if any, and number of satellites.
+* [GroundTruth](../api_reference/structmavsdk_1_1_telemetry_1_1_ground_truth.md)
 * [Health](../api_reference/structmavsdk_1_1_telemetry_1_1_health.md) - calibration status of various sensors and confirmation that position estimates are good enough for position control.
-* [RCStatus](../api_reference/structmavsdk_1_1_telemetry_1_1_r_c_status.md) - connection status, signal strength, and whether RC has ever been connected.
+* [Imu](../api_reference/structmavsdk_1_1_telemetry_1_1_imu.md)
+* [MagneticFieldFrd](../api_reference/structmavsdk_1_1_telemetry_1_1_magnetic_field_frd.md)
+* [Odometry](../api_reference/structmavsdk_1_1_telemetry_1_1_odometry.md)
+* [Position](../api_reference/structmavsdk_1_1_telemetry_1_1_position.md) - latitude and longitude in degrees, and altitude relative to sea level and to the takeoff altitude.
+* [PositionBody](../api_reference/structmavsdk_1_1_telemetry_1_1_position_body.md)
+* [PositionNed](../api_reference/structmavsdk_1_1_telemetry_1_1_position_ned.md)
+* [VelocityNed](../api_reference/structmavsdk_1_1_telemetry_1_1_velocity_ned.md)
+* [VelocityBody](../api_reference/structmavsdk_1_1_telemetry_1_1_velocity_body.md)
+* [PositionVelocityNed](../api_reference/structmavsdk_1_1_telemetry_1_1_position_velocity_ned.md)
+* [Quaternion](../api_reference/structmavsdk_1_1_telemetry_1_1_quaternion.md) - vehicle attitude/orientation as a quaternion
+* [RcStatus](../api_reference/structmavsdk_1_1_telemetry_1_1_rc_status.md) - connection status, signal strength, and whether RC has ever been connected.
+* [StatusText](../api_reference/structmavsdk_1_1_telemetry_1_1_status_text.md)
+
 
 In addition there are a number of methods that return vehicle "state":
 * Current flight mode ([flight_mode()](../api_reference/classmavsdk_1_1_telemetry.md#classmavsdk_1_1_telemetry_1a4972a3968e379d565e7700f2f51158dd)).

--- a/en/guide/telemetry.md
+++ b/en/guide/telemetry.md
@@ -94,7 +94,7 @@ You can set the rate for *each* type of telemetry, and both synchronous or async
 The rate-setting methods are all used in the same way, so we just show one example for both the asynchronous and synchronous methods below.
 In both cases we set the rate for position updates.
 
-To set the position update rate synchronously (in this case using [set_rate_position()](../api_reference/classmavsdk_1_1_telemetry.md#classmavsdk_1_1_telemetry_1a7bb2f0ad795108ea857cbd6b9f802ee2)):
+To set the position update rate synchronously (in this case using [set_rate_position()](../api_reference/classmavsdk_1_1_telemetry.md#classmavsdk_1_1_telemetry_1a665439f3d5f8c58b3ef3dd427cf4782b)):
 ```cpp
 // Set position update rate to 1 Hz.
 const Telemetry::Result set_rate_result = telemetry->set_rate_position(1.0);
@@ -104,7 +104,7 @@ if (set_rate_result != Telemetry::Result::SUCCESS) {
 }
 ```
 
-To set the position update rate asynchronously with [set_rate_position_async()](../api_reference/classmavsdk_1_1_telemetry.md#classmavsdk_1_1_telemetry_1aa8d3e034d11fccb1533d1a782618f4a4) (here we use a *promise* to block until we have a result):
+To set the position update rate asynchronously with [set_rate_position_async()](../api_reference/classmavsdk_1_1_telemetry.md#classmavsdk_1_1_telemetry_1ad7e5b576edb9398c8f5f2f14626b984a) (here we use a *promise* to block until we have a result):
 ```cpp
 {
     std::cout << "Setting rate updates..." << std::endl;
@@ -129,22 +129,23 @@ To set the position update rate asynchronously with [set_rate_position_async()](
 ## Getting Regular Updates
 
 The best way to get telemetry updates is to use the asynchronous methods. 
-These methods are non-blocking - they take a callback function argument and return immediately. 
+These methods are non-blocking; they take a callback function argument and return immediately. 
 The callback will be invoked with a populated `struct` of the associated type as soon as an update message arrives from the vehicle. 
 The rate at which this occurs can be set through the API [as discussed above](#update-rate). 
 
-For example, the [Telemetry::position_async()](../api_reference/classmavsdk_1_1_telemetry.md#classmavsdk_1_1_telemetry_1a36c873a346ec80ffa6440191e57e440a) has the following prototype, where [position_callback_t](../api_reference/classmavsdk_1_1_telemetry.md#classmavsdk_1_1_telemetry_1aadcd5ce9f12b7de8f44b32aff9bc766f) is called with a populated [Position](../api_reference/structmavsdk_1_1_telemetry_1_1_position.md):
+For example, the [Telemetry::subscribe_position()](../api_reference/classmavsdk_1_1_telemetry.md#classmavsdk_1_1_telemetry_1a61bda57b3ca47000ea7e4758b2a33134) has the following prototype, where `callback` is called with a populated [PositionCallback](../api_reference/structmavsdk_1_1_telemetry_1_1_position.md#classmavsdk_1_1_telemetry_1a978b371d636226e198995462afa63552) function:
 ```cpp
-void mavsdk::Telemetry::position_async(position_callback_t callback)
+void mavsdk::Telemetry::subscribe_position(PositionCallback callback)
 ```
 
 The code fragment below shows this method being use with a lambda function for the callback, which simply prints out the current position and altitude).
 ```cpp
-telemetry->position_async([](Telemetry::Position position) {
+telemetry->subscribe_position([](Telemetry::Position position) {
     std::cout << "Altitude: " << position.relative_altitude_m << " m" << std::endl
               << "Latitude: " << position.latitude_deg << std::endl
               << "Longitude: " << position.longitude_deg << std::endl;
 });
+
 ```
 
 
@@ -153,20 +154,25 @@ telemetry->position_async([](Telemetry::Position position) {
 The asynchronous callbacks are updated every time new information is provided by the vehicle. 
 For some types of telemetry you may only wish to report only when the value changes.
 
-The example below shows how to use [flight_mode_async()](../api_reference/classmavsdk_1_1_telemetry.md#classmavsdk_1_1_telemetry_1adede4202304e53466b4df41367a75878) to report only when the current flight mode changes. 
+The example below shows how to use [subscribe_flight_mode()](../api_reference/classmavsdk_1_1_telemetry.md#classmavsdk_1_1_telemetry_1a53db5fb36bf10fbc7ac004a3be9100a4) to report only when the current flight mode changes. 
 The example uses a lambda function callback that captures a variable for the last mode. 
 This variable is compared to the current flight mode to determine whether the value has changed and needs to be reported.
 
 ```cpp
 // Set up callback to monitor flight mode 'changes' 
-Telemetry::FlightMode oldFlightMode=Telemetry::FlightMode::UNKNOWN;
-telemetry->flight_mode_async([&oldFlightMode](Telemetry::FlightMode flightMode) {
+Telemetry::FlightMode oldFlightMode=Telemetry::FlightMode::Unknown;
+telemetry->subscribe_flight_mode([&oldFlightMode](Telemetry::FlightMode flightMode) {
     if (oldFlightMode != flightMode) {
         //Flight mode changed. Print!
-        std::cout << "FlightMode: " << Telemetry::flight_mode_str(flightMode) << std::endl;
+        std::cout << "FlightMode: " << flightMode << std::endl;
         oldFlightMode=flightMode; //Save updated mode.
     }
 });
+```
+
+You can stop flight mode updates altogether with:
+```cpp
+telemetry->subscribe_flight_mode(nullptr);
 ```
 
 This same approach can be used to report only messages that meet some condition.


### PR DESCRIPTION
Prior to creating the 0.25 release

@julianoes This fixes all the broken anchor URLs. I have tried to fix up methods and code fragments to new names if that was obvious from the usage. This also replaces the example code in the examples.
All that should be "OK".

BUT we (you guys) need to review and update the docs like general usage, connections etc in the guide and sanity check them. Lots changed over time that may well not have been updated by me. That stuff is the basic getting started with C++ so it needs to be right. Can you update.

Feel free to merge this PR for now if it si OK. 