### PR TITLE
Remove release page

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -131,7 +131,6 @@
     * [Documentation](contributing/documentation.md)
     * [Release process](contributing/release.md)
   * [Troubleshooting](cpp/troubleshooting.md)
-* [Releases](releases/README.md)
 
 ## Dronecode Shortcuts
 

--- a/en/releases/README.md
+++ b/en/releases/README.md
@@ -1,7 +1,0 @@
-# Releases
-
-> **Warning** The SDK is in beta.
-
-SDK releases can be found on Github:
-* [C++ (Core)](https://github.com/mavlink/MAVSDK/releases)
-* [iOS/Swift](https://github.com/mavlink/MAVSDK-Swift/releases)


### PR DESCRIPTION
I feel like this page is a bit confusing, because it says that MAVSDK is in beta.