### PR TITLE
Update releases info to be accurate

### DIFF
--- a/en/releases/README.md
+++ b/en/releases/README.md
@@ -1,7 +1,15 @@
 # Releases
 
-> **Warning** The SDK is in beta.
+SDK releases are made independently for each programming language.
+These can typically be found on Github, but may also be available through package managers etc (as listed below).
 
 SDK releases can be found on Github:
-* [C++ (Core)](https://github.com/mavlink/MAVSDK/releases)
-* [iOS/Swift](https://github.com/mavlink/MAVSDK-Swift/releases)
+* C++ (Core)
+  - [Github](https://github.com/mavlink/MAVSDK/releases)
+  - [Docs](https://mavsdk.mavlink.io/develop/en/cpp/). Note, the version switcher for the library specifies the C++ release version.
+* iOS/Swift
+  * [Github](https://github.com/mavlink/MAVSDK-Swift/releases)
+* Python
+  * [PyPi](https://pypi.org/project/mavsdk)
+  * [Github](https://github.com/mavlink/MAVSDK-Python/releases)
+  * [Docs](http://mavsdk-python-docs.s3-website.eu-central-1.amazonaws.com/) ( for current release)


### PR DESCRIPTION
Alternative to https://github.com/mavlink/MAVSDK-docs/pull/217

@JonasVautherin I think there is value in outlining where releases can be found in one place, and also making it clear that the release cycle for the different runtimes is not co-ordinated. So rather than deleting the page, I deleted the "in beta" note.

We could add this back "per runtime". 

What else would we say?