### PR TITLE
Remove the warning for linux arm support of mavsdk-python

### DIFF
--- a/en/getting_started/installation.md
+++ b/en/getting_started/installation.md
@@ -38,8 +38,6 @@ Use `pip3` to install [MAVSDK-Python](https://github.com/mavlink/MAVSDK-Python#m
 ```bash
 pip3 install mavsdk
 ```
-> **Note** MAVSDK-Python is currently only available for Windows, macOS, and Linux x86_64.
-  It is not yet suppported for Linux ARM platfroms like RPi (see [MAVSDK-Python#117](https://github.com/mavlink/MAVSDK-Python/issues/117)).
 
   
 ## Swift (iOS) {#ios}


### PR DESCRIPTION
Since Linux ARM platforms are [supported ](https://pypi.org/project/mavsdk/#files) now, there is no need to raise this note for MAVSDK-Python installation.