### PR TITLE
README: Update reference to DF

### DIFF
--- a/en/README.md
+++ b/en/README.md
@@ -5,8 +5,7 @@
 
 *MAVSDK* is a [MAVLink](https://mavlink.io/en/) Library with APIs for [C++](cpp/README.md), [iOS](http://dronecode-sdk-swift.s3.eu-central-1.amazonaws.com/docs/master/index.html), Python and Android.
 
-> **Tip** The SDK is the best way to integrate with a flight stack over MAVLink!
-  It is supported by [Dronecode](https://www.dronecode.org/), ensuring that it is robust, well tested, and maintained.
+> **Tip** The SDK is the best way to integrate with a flight stack over MAVLink, and it is supported by the [Dronecode Foundation](https://www.dronecode.org/), ensuring that it is robust, well tested, and maintained.
 
 The library provides a simple API for managing one or more vehicles, providing programmatic access to vehicle information and telemetry, and control over missions, movement and other operations.
 


### PR DESCRIPTION
Fixes the reference to Dronecode, we should be calling it the Dronecode Foundation everywhere.