### PR TITLE
Navigation: Helpful Shortcuts (remove Dronecode)

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -142,7 +142,7 @@
 * [Autogeneration](autogen/README.md)
 * [Releases](releases/README.md)
 
-## Dronecode Shortcuts
+## Helpful Shortcuts
 
 * [PX4 Developer Guide](https://dev.px4.io/master/en/)
 * [PX4 User Guide](https://docs.px4.io/master/en/)


### PR DESCRIPTION
My original intention was to update this to say "Dronecode Foundation Shortcuts," which caused the text to create a second line, making it look terrible. I instead opted for removing "Dronecode" altogether and leaving it as "Helpful Shortcuts."