### PR TITLE
contributing: omit branches for bugfix releases

### DIFF
--- a/book.json
+++ b/book.json
@@ -69,8 +69,8 @@
                     "text": "main"
                 },
                 {
-                    "value": "https://mavsdk.mavlink.io/v0.38.1/en/",
-                    "text": "v0.38.1"
+                    "value": "https://mavsdk.mavlink.io/v0.38/en/",
+                    "text": "v0.38"
                 },
                 {
                     "value": "https://mavsdk.mavlink.io/v0.37.0/en/",

--- a/en/contributing/release.md
+++ b/en/contributing/release.md
@@ -41,12 +41,12 @@ These are the instructions on how to get a release out the door.
      ```
      git switch main
      git pull
-     git switch -c vX.Y.Z
+     git switch -c vX.Y
      ```
-   - Modify **book.json** in the vX.Y.Z branch to change the value of `github_branch` to match the new branch: `"github_branch": "vX.Y.Z"`
+   - Modify **book.json** in the vX.Y branch to change the value of `github_branch` to match the new branch: `"github_branch": "vX.Y"`
    - Push the branch to the upstream repo
      ```
-     git push origin vX.Y.Z
+     git push origin vX.Y
      ```
 1. Add the branch to the version checker in main branch [book.json](https://github.com/mavlink/MAVSDK-docs/blob/main/book.json) (see pattern below `versions`).
 


### PR DESCRIPTION
We should not create new branches, doc entries for patch releases because by definition these should only include bugfixes and no API changes.