### PR TITLE
Update API ref to 0.40

### DIFF
--- a/book.json
+++ b/book.json
@@ -16,7 +16,7 @@
         "toolbar@git+https://github.com/hamishwillee/gitbook-plugin-toolbar.git",
         "validate-links",
         "anchors",
-        "theme-dronecode@git+https://github.com/dronecode/theme-dronecode.git",
+        "theme-dronecode@git+https://github.com/Dronecode/theme-dronecode.git",
         "versions-select@git+https://github.com/Dronecode/gitbook-plugin-versions-select.git"
     ],
     "pluginsConfig": {

--- a/en/cpp/api_reference/classmavsdk_1_1_action.md
+++ b/en/cpp/api_reference/classmavsdk_1_1_action.md
@@ -52,6 +52,8 @@ void | [do_orbit_async](#classmavsdk_1_1_action_1aac9a2ac57a6e8f734b25c2e6dc0729
 [Result](classmavsdk_1_1_action.md#classmavsdk_1_1_action_1adc2e13257ef13de0e7610cf879a0ec51) | [do_orbit](#classmavsdk_1_1_action_1ac7447a86016bee3576643563079288b9) (float radius_m, float velocity_ms, [OrbitYawBehavior](classmavsdk_1_1_action.md#classmavsdk_1_1_action_1ad9dd7c5e85dda1ae188df75998375c92) yaw_behavior, double latitude_deg, double longitude_deg, double absolute_altitude_m)const | Send command do orbit to the drone.
 void | [hold_async](#classmavsdk_1_1_action_1aad198c883e7ace1cf4556c3b15bd8ad8) (const [ResultCallback](classmavsdk_1_1_action.md#classmavsdk_1_1_action_1a70a7b6e742d0c86728dc2e1827dacccd) callback) | Send command to hold position (a.k.a. "Loiter").
 [Result](classmavsdk_1_1_action.md#classmavsdk_1_1_action_1adc2e13257ef13de0e7610cf879a0ec51) | [hold](#classmavsdk_1_1_action_1a3440724492453e88d2399be7bae6e7c4) () const | Send command to hold position (a.k.a. "Loiter").
+void | [set_actuator_async](#classmavsdk_1_1_action_1a2206033eb3469d2ae81b9cf994bfda98) (int32_t index, float value, const [ResultCallback](classmavsdk_1_1_action.md#classmavsdk_1_1_action_1a70a7b6e742d0c86728dc2e1827dacccd) callback) | Send command to set the value of an actuator.
+[Result](classmavsdk_1_1_action.md#classmavsdk_1_1_action_1adc2e13257ef13de0e7610cf879a0ec51) | [set_actuator](#classmavsdk_1_1_action_1ad30beac27f05c62dcf6a3d0928b86e4c) (int32_t index, float value)const | Send command to set the value of an actuator.
 void | [transition_to_fixedwing_async](#classmavsdk_1_1_action_1aa56181441cd64e092a8fb91a38c7c9fd) (const [ResultCallback](classmavsdk_1_1_action.md#classmavsdk_1_1_action_1a70a7b6e742d0c86728dc2e1827dacccd) callback) | Send command to transition the drone to fixedwing.
 [Result](classmavsdk_1_1_action.md#classmavsdk_1_1_action_1adc2e13257ef13de0e7610cf879a0ec51) | [transition_to_fixedwing](#classmavsdk_1_1_action_1a8d5cf999a48ea3859ec75db27cf4fbda) () const | Send command to transition the drone to fixedwing.
 void | [transition_to_multicopter_async](#classmavsdk_1_1_action_1a8c109076641b5c9aa6dd78ea8b913529) (const [ResultCallback](classmavsdk_1_1_action.md#classmavsdk_1_1_action_1a70a7b6e742d0c86728dc2e1827dacccd) callback) | Send command to transition the drone to multicopter.
@@ -663,6 +665,41 @@ Note: this command is specific to the PX4 Autopilot flight stack as it implies a
 
 
 This function is blocking. See 'hold_async' for the non-blocking counterpart.
+
+**Returns**
+
+&emsp;[Result](classmavsdk_1_1_action.md#classmavsdk_1_1_action_1adc2e13257ef13de0e7610cf879a0ec51) - Result of request.
+
+### set_actuator_async() {#classmavsdk_1_1_action_1a2206033eb3469d2ae81b9cf994bfda98}
+```cpp
+void mavsdk::Action::set_actuator_async(int32_t index, float value, const ResultCallback callback)
+```
+
+
+Send command to set the value of an actuator.
+
+This function is non-blocking. See 'set_actuator' for the blocking counterpart.
+
+**Parameters**
+
+* int32_t **index** - 
+* float **value** - 
+* const [ResultCallback](classmavsdk_1_1_action.md#classmavsdk_1_1_action_1a70a7b6e742d0c86728dc2e1827dacccd) **callback** - 
+
+### set_actuator() {#classmavsdk_1_1_action_1ad30beac27f05c62dcf6a3d0928b86e4c}
+```cpp
+Result mavsdk::Action::set_actuator(int32_t index, float value) const
+```
+
+
+Send command to set the value of an actuator.
+
+This function is blocking. See 'set_actuator_async' for the non-blocking counterpart.
+
+**Parameters**
+
+* int32_t **index** - 
+* float **value** - 
 
 **Returns**
 

--- a/en/cpp/api_reference/classmavsdk_1_1_camera.md
+++ b/en/cpp/api_reference/classmavsdk_1_1_camera.md
@@ -306,6 +306,7 @@ Value | Description
 <span id="classmavsdk_1_1_camera_1a2a84df3938372f4f302576227b308bcfa902b0d55fddef6f8d651fe1035b7d4bd"></span> `Error` | An error has occured while executing the command. 
 <span id="classmavsdk_1_1_camera_1a2a84df3938372f4f302576227b308bcfac85a251cc457840f1e032f1b733e9398"></span> `Timeout` | Command timed out. 
 <span id="classmavsdk_1_1_camera_1a2a84df3938372f4f302576227b308bcfa5a738160747f39c20e9f65416931c974"></span> `WrongArgument` | Command has wrong argument(s). 
+<span id="classmavsdk_1_1_camera_1a2a84df3938372f4f302576227b308bcfa1119faf72ba0dfb23aeea644fed960ad"></span> `NoSystem` | No system connected. 
 
 ## Member Function Documentation
 

--- a/en/cpp/api_reference/classmavsdk_1_1_ftp.md
+++ b/en/cpp/api_reference/classmavsdk_1_1_ftp.md
@@ -191,6 +191,7 @@ Value | Description
 <span id="classmavsdk_1_1_ftp_1a4cc4f42a3ef6d63403d811e594b946e4a627251310d3384b591e4138be21145d5"></span> `InvalidParameter` | Invalid parameter. 
 <span id="classmavsdk_1_1_ftp_1a4cc4f42a3ef6d63403d811e594b946e4ab4080bdf74febf04d578ff105cce9d3f"></span> `Unsupported` | Unsupported command. 
 <span id="classmavsdk_1_1_ftp_1a4cc4f42a3ef6d63403d811e594b946e4aca3da8f495e4e628912a7798655da6c2"></span> `ProtocolError` | General protocol error. 
+<span id="classmavsdk_1_1_ftp_1a4cc4f42a3ef6d63403d811e594b946e4a1119faf72ba0dfb23aeea644fed960ad"></span> `NoSystem` | No system connected. 
 
 ## Member Function Documentation
 

--- a/en/cpp/api_reference/classmavsdk_1_1_geofence.md
+++ b/en/cpp/api_reference/classmavsdk_1_1_geofence.md
@@ -128,6 +128,7 @@ Value | Description
 <span id="classmavsdk_1_1_geofence_1ab64d6e3b9aeb9b6d5e45ae8a843a2642ad8a942ef2b04672adfafef0ad817a407"></span> `Busy` | Vehicle is busy. 
 <span id="classmavsdk_1_1_geofence_1ab64d6e3b9aeb9b6d5e45ae8a843a2642ac85a251cc457840f1e032f1b733e9398"></span> `Timeout` | Request timed out. 
 <span id="classmavsdk_1_1_geofence_1ab64d6e3b9aeb9b6d5e45ae8a843a2642a253ca7dd096ee0956cccee4d376cab8b"></span> `InvalidArgument` | Invalid argument. 
+<span id="classmavsdk_1_1_geofence_1ab64d6e3b9aeb9b6d5e45ae8a843a2642a1119faf72ba0dfb23aeea644fed960ad"></span> `NoSystem` | No system connected. 
 
 ## Member Function Documentation
 

--- a/en/cpp/api_reference/classmavsdk_1_1_gimbal.md
+++ b/en/cpp/api_reference/classmavsdk_1_1_gimbal.md
@@ -172,6 +172,7 @@ Value | Description
 <span id="classmavsdk_1_1_gimbal_1aa732ec0bd49ac03b7910199d635f76aca902b0d55fddef6f8d651fe1035b7d4bd"></span> `Error` | Error occurred sending the command. 
 <span id="classmavsdk_1_1_gimbal_1aa732ec0bd49ac03b7910199d635f76acac85a251cc457840f1e032f1b733e9398"></span> `Timeout` | Command timed out. 
 <span id="classmavsdk_1_1_gimbal_1aa732ec0bd49ac03b7910199d635f76acab4080bdf74febf04d578ff105cce9d3f"></span> `Unsupported` | Functionality not supported. 
+<span id="classmavsdk_1_1_gimbal_1aa732ec0bd49ac03b7910199d635f76aca1119faf72ba0dfb23aeea644fed960ad"></span> `NoSystem` | No system connected. 
 
 ## Member Function Documentation
 

--- a/en/cpp/api_reference/classmavsdk_1_1_info.md
+++ b/en/cpp/api_reference/classmavsdk_1_1_info.md
@@ -131,6 +131,7 @@ Value | Description
 <span id="classmavsdk_1_1_info_1ab1798ed39271915800b25aaa05d1d45aa88183b946cc5f0e8c96b2e66e1c74a7e"></span> `Unknown` | Unknown result. 
 <span id="classmavsdk_1_1_info_1ab1798ed39271915800b25aaa05d1d45aa505a83f220c02df2f85c3810cd9ceb38"></span> `Success` | Request succeeded. 
 <span id="classmavsdk_1_1_info_1ab1798ed39271915800b25aaa05d1d45aa56c1e4870d2594d9fd4d91ffaf1e3e70"></span> `InformationNotReceivedYet` | Information has not been received yet. 
+<span id="classmavsdk_1_1_info_1ab1798ed39271915800b25aaa05d1d45aa1119faf72ba0dfb23aeea644fed960ad"></span> `NoSystem` | No system is connected. 
 
 ## Member Function Documentation
 

--- a/en/cpp/api_reference/classmavsdk_1_1_log_files.md
+++ b/en/cpp/api_reference/classmavsdk_1_1_log_files.md
@@ -151,6 +151,7 @@ Value | Description
 <span id="classmavsdk_1_1_log_files_1a43e5425f17cd8a6830ff6fd952a724cdac85a251cc457840f1e032f1b733e9398"></span> `Timeout` | A timeout happened. 
 <span id="classmavsdk_1_1_log_files_1a43e5425f17cd8a6830ff6fd952a724cda253ca7dd096ee0956cccee4d376cab8b"></span> `InvalidArgument` | Invalid argument. 
 <span id="classmavsdk_1_1_log_files_1a43e5425f17cd8a6830ff6fd952a724cda17fd85d9b010cda721a6aa7db5af2b28"></span> `FileOpenFailed` | File open failed. 
+<span id="classmavsdk_1_1_log_files_1a43e5425f17cd8a6830ff6fd952a724cda1119faf72ba0dfb23aeea644fed960ad"></span> `NoSystem` | No system is connected. 
 
 ## Member Function Documentation
 

--- a/en/cpp/api_reference/classmavsdk_1_1_mission.md
+++ b/en/cpp/api_reference/classmavsdk_1_1_mission.md
@@ -173,6 +173,7 @@ Value | Description
 <span id="classmavsdk_1_1_mission_1ab3114c63db76bdc37460939a1f3316f6a6b0ce476dfc17eed72967386f52ede78"></span> `NoMissionAvailable` | No mission available on the system. 
 <span id="classmavsdk_1_1_mission_1ab3114c63db76bdc37460939a1f3316f6aefcaef698baace312f79a53019bd9cf4"></span> `UnsupportedMissionCmd` | Unsupported mission command. 
 <span id="classmavsdk_1_1_mission_1ab3114c63db76bdc37460939a1f3316f6a3465fd31285ebd60597cf59bff9db01a"></span> `TransferCancelled` | [Mission](classmavsdk_1_1_mission.md) transfer (upload or download) has been cancelled. 
+<span id="classmavsdk_1_1_mission_1ab3114c63db76bdc37460939a1f3316f6a1119faf72ba0dfb23aeea644fed960ad"></span> `NoSystem` | No system connected. 
 
 ## Member Function Documentation
 

--- a/en/cpp/api_reference/classmavsdk_1_1_mission_raw.md
+++ b/en/cpp/api_reference/classmavsdk_1_1_mission_raw.md
@@ -187,6 +187,7 @@ Value | Description
 <span id="classmavsdk_1_1_mission_raw_1a7ea2a624818ebb5a3e209cc275d58eafa3465fd31285ebd60597cf59bff9db01a"></span> `TransferCancelled` | [Mission](classmavsdk_1_1_mission.md) transfer (upload or download) has been cancelled. 
 <span id="classmavsdk_1_1_mission_raw_1a7ea2a624818ebb5a3e209cc275d58eafac73901782ccb07eeaf03f1a27e323e4f"></span> `FailedToOpenQgcPlan` | Failed to open the QGroundControl plan. 
 <span id="classmavsdk_1_1_mission_raw_1a7ea2a624818ebb5a3e209cc275d58eafabd0579c3163a37a4bc4fe181903cc1e9"></span> `FailedToParseQgcPlan` | Failed to parse the QGroundControl plan. 
+<span id="classmavsdk_1_1_mission_raw_1a7ea2a624818ebb5a3e209cc275d58eafa1119faf72ba0dfb23aeea644fed960ad"></span> `NoSystem` | No system connected. 
 
 ## Member Function Documentation
 

--- a/en/cpp/api_reference/classmavsdk_1_1_param.md
+++ b/en/cpp/api_reference/classmavsdk_1_1_param.md
@@ -132,6 +132,7 @@ Value | Description
 <span id="classmavsdk_1_1_param_1afde69c8b60c41e2f21db148d211881dfa094a6f6b0868122a9dd008cb91c083e4"></span> `ConnectionError` | Connection error. 
 <span id="classmavsdk_1_1_param_1afde69c8b60c41e2f21db148d211881dfafdf152936dcbf201445440856357f6ac"></span> `WrongType` | Wrong type. 
 <span id="classmavsdk_1_1_param_1afde69c8b60c41e2f21db148d211881dfaa2b5cfc4e45ca036892b3dadc483e655"></span> `ParamNameTooLong` | Parameter name too long (> 16). 
+<span id="classmavsdk_1_1_param_1afde69c8b60c41e2f21db148d211881dfa1119faf72ba0dfb23aeea644fed960ad"></span> `NoSystem` | No system connected. 
 
 ## Member Function Documentation
 

--- a/en/cpp/api_reference/classmavsdk_1_1_tune.md
+++ b/en/cpp/api_reference/classmavsdk_1_1_tune.md
@@ -155,6 +155,7 @@ Value | Description
 <span id="classmavsdk_1_1_tune_1aed2b008974298098cedd69b7e95e909dab94ce655e90ee954ba1c4c5d0e13659e"></span> `InvalidTempo` | Invalid tempo (range: 32 - 255). 
 <span id="classmavsdk_1_1_tune_1aed2b008974298098cedd69b7e95e909da088c77b60655734bff629e03e1968495"></span> `TuneTooLong` | Invalid tune: encoded string must be at most 247 chars. 
 <span id="classmavsdk_1_1_tune_1aed2b008974298098cedd69b7e95e909da902b0d55fddef6f8d651fe1035b7d4bd"></span> `Error` | Failed to send the request. 
+<span id="classmavsdk_1_1_tune_1aed2b008974298098cedd69b7e95e909da1119faf72ba0dfb23aeea644fed960ad"></span> `NoSystem` | No system connected. 
 
 ## Member Function Documentation
 

--- a/en/cpp/api_reference/namespacemavsdk.md
+++ b/en/cpp/api_reference/namespacemavsdk.md
@@ -7,8 +7,6 @@ Namespace for all mavsdk types.
 
 ## Data Structures
 
-* [mavsdk::Mavsdk](classmavsdk_1_1_mavsdk.md)
-* [mavsdk::PluginBase](classmavsdk_1_1_plugin_base.md)
 * [mavsdk::Action](classmavsdk_1_1_action.md)
 * [mavsdk::Calibration](classmavsdk_1_1_calibration.md)
 * [mavsdk::Camera](classmavsdk_1_1_camera.md)
@@ -21,18 +19,20 @@ Namespace for all mavsdk types.
 * [mavsdk::LogFiles](classmavsdk_1_1_log_files.md)
 * [mavsdk::ManualControl](classmavsdk_1_1_manual_control.md)
 * [mavsdk::MavlinkPassthrough](classmavsdk_1_1_mavlink_passthrough.md)
+* [mavsdk::Mavsdk](classmavsdk_1_1_mavsdk.md)
 * [mavsdk::Mission](classmavsdk_1_1_mission.md)
 * [mavsdk::MissionRaw](classmavsdk_1_1_mission_raw.md)
 * [mavsdk::Mocap](classmavsdk_1_1_mocap.md)
 * [mavsdk::Offboard](classmavsdk_1_1_offboard.md)
 * [mavsdk::Param](classmavsdk_1_1_param.md)
+* [mavsdk::PluginBase](classmavsdk_1_1_plugin_base.md)
 * [mavsdk::ServerUtility](classmavsdk_1_1_server_utility.md)
 * [mavsdk::Shell](classmavsdk_1_1_shell.md)
+* [mavsdk::System](classmavsdk_1_1_system.md)
 * [mavsdk::Telemetry](classmavsdk_1_1_telemetry.md)
 * [mavsdk::TrackingServer](classmavsdk_1_1_tracking_server.md)
 * [mavsdk::Transponder](classmavsdk_1_1_transponder.md)
 * [mavsdk::Tune](classmavsdk_1_1_tune.md)
-* [mavsdk::System](classmavsdk_1_1_system.md)
 
 ## Enumerations
 

--- a/en/cpp/api_reference/structmavsdk_1_1_info_1_1_identification.md
+++ b/en/cpp/api_reference/structmavsdk_1_1_info_1_1_identification.md
@@ -12,6 +12,8 @@
 
 std::string [hardware_uid](#structmavsdk_1_1_info_1_1_identification_1a68be9823aae193b5473191d287b5e385) {} - UID of the hardware. This refers to uid2 of MAVLink. If the system does not support uid2 yet, this is all zeros.
 
+uint64_t [legacy_uid](#structmavsdk_1_1_info_1_1_identification_1a2429c1ffc3fbda0d55e85fa5a6f79dc1) {} - Legacy UID of the hardware, referred to as uid in MAVLink (formerly exposed during system discovery as UUID).
+
 
 ## Field Documentation
 
@@ -24,4 +26,14 @@ std::string mavsdk::Info::Identification::hardware_uid {}
 
 
 UID of the hardware. This refers to uid2 of MAVLink. If the system does not support uid2 yet, this is all zeros.
+
+
+### legacy_uid {#structmavsdk_1_1_info_1_1_identification_1a2429c1ffc3fbda0d55e85fa5a6f79dc1}
+
+```cpp
+uint64_t mavsdk::Info::Identification::legacy_uid {}
+```
+
+
+Legacy UID of the hardware, referred to as uid in MAVLink (formerly exposed during system discovery as UUID).
 

--- a/en/cpp/api_reference/structmavsdk_1_1_mission_1_1_mission_item.md
+++ b/en/cpp/api_reference/structmavsdk_1_1_mission_1_1_mission_item.md
@@ -40,6 +40,8 @@ float [loiter_time_s](#structmavsdk_1_1_mission_1_1_mission_item_1aa54196266e57f
 
 double [camera_photo_interval_s](#structmavsdk_1_1_mission_1_1_mission_item_1a7b48c46ecb52f115e5461a944f619612) { 1.0} - [Camera](classmavsdk_1_1_camera.md) photo interval to use after this mission item (in seconds)
 
+float [acceptance_radius_m](#structmavsdk_1_1_mission_1_1_mission_item_1a9114a16c5405dacb35f45ae37f343665) { float(NAN)} - Radius for completing a mission item (in metres)
+
 
 ## Member Enumeration Documentation
 
@@ -160,4 +162,14 @@ double mavsdk::Mission::MissionItem::camera_photo_interval_s { 1.0}
 
 
 [Camera](classmavsdk_1_1_camera.md) photo interval to use after this mission item (in seconds)
+
+
+### acceptance_radius_m {#structmavsdk_1_1_mission_1_1_mission_item_1a9114a16c5405dacb35f45ae37f343665}
+
+```cpp
+float mavsdk::Mission::MissionItem::acceptance_radius_m { float(NAN)}
+```
+
+
+Radius for completing a mission item (in metres)
 


### PR DESCRIPTION
Howdy @julianoes 
All I've done is run the generator and copy in the reference.

The actuator documentation looks "insufficient" - there is no information about the values that get passed as arguments. Any chance of at least a cross link to mavlink docs for SET_ACTUATOR? Further, can I have an example to use for updating https://docs.px4.io/master/en/payloads/#mavsdk-example-script and then we might link to that? We need that anyway.

Feel free to merge this as-is for now and we can continue the discussion.

PS Generator modification came out of this: https://github.com/mavlink/MAVSDK/pull/1453