### PR TITLE
Run codespell on docs

### DIFF
--- a/en/README.md
+++ b/en/README.md
@@ -14,7 +14,7 @@ MAVSDK is cross-platform: Linux, macOS, Windows, Android and iOS.
 
 ## Programming Languages
 
-MAVSDK is primarly written in C++ with wrappers available for several programming languages:
+MAVSDK is primarily written in C++ with wrappers available for several programming languages:
 
 - [MAVSDK-C++](https://github.com/mavlink/MAVSDK) (2016): Used in production.
 - [MAVSDK-Swift](https://github.com/mavlink/MAVSDK-Swift) (2018): Used in production.

--- a/en/cpp/api_changes.md
+++ b/en/cpp/api_changes.md
@@ -157,8 +157,8 @@ This mostly worked fine, however, had some drawbacks:
   This is not very intuitive and also means additional checks inside the plugins are required.
 - The ownership model is not very clear as `Mavsdk` owns the `System` but then each plugin only seems to require the `System`.
   Internally, the plugins still require `Mavsdk` to be alive and working but that's not apparent through the API.
-- If there are multiple sytems they need to be accessed using the `uuid`.
-  This seems like a crutch because essentially we would just like to have a `std::vector` of systems but of course that's not posible with references.
+- If there are multiple systems they need to be accessed using the `uuid`.
+  This seems like a crutch because essentially we would just like to have a `std::vector` of systems but of course that's not possible with references.
 
 As the API for the uid was about the change anyway (see above) it seemed time to redesign the API to access systems with these considerations in mind.
 

--- a/en/cpp/contributing/plugins.md
+++ b/en/cpp/contributing/plugins.md
@@ -55,8 +55,8 @@ Looking at the plugin structure again, this means that some of the files are aut
         ├── CMakeLists.txt       # auto-generated
         ├── example.cpp          # auto-generated
         ├── example.h            # auto-generated
-        ├── example_impl.cpp     # hand-written (can initally be generated)
-        ├── example_impl.h       # hand-written (can initally be generated)
+        ├── example_impl.cpp     # hand-written (can initially be generated)
+        ├── example_impl.h       # hand-written (can initially be generated)
         └── example_foo_test.cpp  # optional
 ```
 
@@ -188,7 +188,7 @@ Once the proto file has been created, you can generate all files required for th
    tools/fix_style.sh .
    ```
 
-> **Note** the files `my_new_plugin.h` and `my_new_plugin.cpp` are generated and overwritten everytime the script is run.
+> **Note** the files `my_new_plugin.h` and `my_new_plugin.cpp` are generated and overwritten every time the script is run.
   However, the files `my_new_plugin_impl.h` and `my_new_plugin_impl.cpp` are only generated once.
   To re-generate them, delete them and run the script again.
   This approach is used to prevent the script from overwriting your local changes.
@@ -196,7 +196,7 @@ Once the proto file has been created, you can generate all files required for th
 ### Actually implement MAVLink messages
 
 You can now add the actual "business logic" which is usually sending and receiving MAVLink messages, waiting for timeouts, etc.
-All implementation goes into the files `my_new_plugin_impl.h` and `my_new_plugin_impl.cpp` or additional files for separete classes required.
+All implementation goes into the files `my_new_plugin_impl.h` and `my_new_plugin_impl.cpp` or additional files for separate classes required.
 
 You can also add unit tests with `unittest_source_files`, as [discussed below](#adding_unit_tests).
 

--- a/en/cpp/examples/autopilot_server.md
+++ b/en/cpp/examples/autopilot_server.md
@@ -243,12 +243,12 @@ Altitude: 10 m
 
 ## How it works
 
-By creating two MAVSDK instances on seperate threads, configuring them and then using different plugins on each, we are able to create a full MAVLink system (GCS <-> Vehicle)
+By creating two MAVSDK instances on separate threads, configuring them and then using different plugins on each, we are able to create a full MAVLink system (GCS <-> Vehicle)
 in one program.
 
 Each plugin (and it's respective server plugin) implements a particular MAVLink service.
 By utilising the server plugins and client plugins we are able to create a full MAVLink
-system, without the need for a seperate external autopilot.
+system, without the need for a separate external autopilot.
 
 ## Source code {#source_code}
 

--- a/en/cpp/guide/offboard.md
+++ b/en/cpp/guide/offboard.md
@@ -92,7 +92,7 @@ if (result != Offboard::Result::Success) {
 ## Velocity Setpoints
 
 The API provides methods to set velocity and yaw components using the NED frame (`set_velocity_ned()`) and the body frame (`set_velocity_body()`).
-The difference is that NED is relative to an absolute co-ordinate system (North, East, Down) while body frame is relative to the vehicle orientation (front, right, down).
+The difference is that NED is relative to an absolute coordinate system (North, East, Down) while body frame is relative to the vehicle orientation (front, right, down).
 
 The NED frame is used to move towards a specific compass direction or face the vehicle in a specific compass direction.
 Body frame is usually used for tasks where the vehicle needs to *deviate* from the current path (e.g. to avoid an obstacle) or to rotate the vehicle at a specific rate.
@@ -121,7 +121,7 @@ Examples:
 
 ### Go Up or Down
 
-Both co-ordinate systems use the same definition for "down", and both methods take an argument where the third value is used to specify the velocity component in this direction.
+Both coordinate systems use the same definition for "down", and both methods take an argument where the third value is used to specify the velocity component in this direction.
 The following examples show how you set the velocity component down (positive) or up (negative) using the two methods:
 
 Examples:

--- a/en/faq.md
+++ b/en/faq.md
@@ -11,7 +11,7 @@ Additionally, MAVSDK should be able to run efficiently in embedded setups, e.g. 
 Yes.
 - The MAVSDK C++ library allows C++ applications to connect to multiple vehicles at a time.
 - Python, Swift, and other language wrappers can only connect to a _single vehicle at a time_.
-  However you can intantiate multiple copies of wrappers in order to connect to multiple systems.
+  However you can instantiate multiple copies of wrappers in order to connect to multiple systems.
 
 A maximum of 255 vehicles can be connected.
 


### PR DESCRIPTION
This is the result of running codespell on the docs like:
```
codespell -s -L "ned"
```
Other than a deep desire to change `PositionNed ==> positioned` nothing found in protos. 
Docs had a few small typos, all fixed.

From which I can only assume that there is spell checking going on already :-)