### PR TITLE
Make label on front of version v2 say v2 - not main

### DIFF
--- a/book.json
+++ b/book.json
@@ -3,7 +3,7 @@
     "title": "MAVSDK Guide",
     "variables": {
         "logo": "./assets/site/sdk_logo_full.png",
-        "github_branch": "main"
+        "github_branch": "v2.0"
     },
     "plugins": [
         "youtube",


### PR DESCRIPTION
As it is now

![image](https://github.com/mavlink/MAVSDK-docs/assets/5368500/1bb7c5c3-ac84-4899-ae87-0bca4ea71d7d)
