### PR TITLE
Remove plugin library linking instructions from docs

### DIFF
--- a/en/cpp/guide/follow_me.md
+++ b/en/cpp/guide/follow_me.md
@@ -38,7 +38,7 @@ The main steps are:
    For example (basic code without error checking):
    ```
    #include <mavsdk/mavsdk.h>
-   Mavsdk mavsdk;
+   Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
    ConnectionResult conn_result = mavsdk.add_udp_connection();
    // Wait for the system to connect via heartbeat
    while (mavsdk.system().size() == 0) {

--- a/en/cpp/guide/missions.md
+++ b/en/cpp/guide/missions.md
@@ -55,7 +55,7 @@ The main steps are:
    For example (basic code without error checking):
    ```
    #include <mavsdk/mavsdk.h>
-   Mavsdk mavsdk;
+   Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
    ConnectionResult conn_result = mavsdk.add_udp_connection();
    // Wait for the system to connect via heartbeat
    while (mavsdk.system().size() == 0) {

--- a/en/cpp/guide/offboard.md
+++ b/en/cpp/guide/offboard.md
@@ -34,7 +34,7 @@ The main steps are:
 1. [Create a connection](../guide/connections.md) to a `system`. For example (basic code without error checking):
    ```
    #include <mavsdk/mavsdk.h>
-   Mavsdk mavsdk;
+   Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
    ConnectionResult conn_result = mavsdk.add_udp_connection();
    // Wait for the system to connect via heartbeat
    while (mavsdk.system().size() == 0) {

--- a/en/cpp/guide/taking_off_landing.md
+++ b/en/cpp/guide/taking_off_landing.md
@@ -16,19 +16,6 @@ General instructions are provided in the topic: [Using Plugins](../guide/using_p
 
 The main steps are:
 
-1. Link the plugin library into your application.
-   Do this by adding `mavsdk_action` to the `target_link_libraries` section of the app's *cmake* build definition file
-
-   ```cmake
-   find_package(MAVSDK REQUIRED)
-
-   target_link_libraries(your_application_name
-     MAVSDK::mavsdk
-     ...
-     MAVSDK::mavsdk_action
-     ...
-   )
-   ```
 1. [Create a connection](../guide/connections.md) to a `system`. For example (basic code without error checking):
    ```
    #include <mavsdk/mavsdk.h>

--- a/en/cpp/guide/taking_off_landing.md
+++ b/en/cpp/guide/taking_off_landing.md
@@ -19,7 +19,7 @@ The main steps are:
 1. [Create a connection](../guide/connections.md) to a `system`. For example (basic code without error checking):
    ```
    #include <mavsdk/mavsdk.h>
-   Mavsdk mavsdk;
+   Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
    ConnectionResult conn_result = mavsdk.add_udp_connection();
    // Wait for the system to connect via heartbeat
    while (mavsdk.system().size() == 0) {

--- a/en/cpp/guide/telemetry.md
+++ b/en/cpp/guide/telemetry.md
@@ -54,7 +54,7 @@ The main steps are:
 1. [Create a connection](../guide/connections.md) to a `system`. For example (basic code without error checking):
    ```
    #include <mavsdk/mavsdk.h>
-   Mavsdk mavsdk;
+   Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
    ConnectionResult conn_result = mavsdk.add_udp_connection();
    // Wait for the system to connect via heartbeat
    while (mavsdk.system().size() == 0) {

--- a/en/cpp/guide/telemetry.md
+++ b/en/cpp/guide/telemetry.md
@@ -51,19 +51,6 @@ General instructions are provided in the topic: [Using Plugins](../guide/using_p
 
 The main steps are:
 
-1. Link the plugin library into your application.
-   Do this by adding `mavsdk_telemetry` to the `target_link_libraries` section of the app's *cmake* build definition file
-
-   ```cmake
-    find_package(MAVSDK REQUIRED)
-
-   target_link_libraries(your_application_name
-     MAVSDK::mavsdk
-     ...
-     MAVSDK::mavsdk_telemetry
-     ...
-   )
-   ```
 1. [Create a connection](../guide/connections.md) to a `system`. For example (basic code without error checking):
    ```
    #include <mavsdk/mavsdk.h>


### PR DESCRIPTION
The following sections were removed from the 'taking_off_landing.md' and 'telemetry.md' documentation files:

1. Instructions for linking the 'mavsdk_telemetry' plugin library to the application's CMake build definition file.
2. Instructions for linking the 'mavsdk_action' plugin library to the application's CMake build definition file.

With recent versions of MAVSDK, you only need MAVSDK::mavsdk and hence these sections are removed.