### PR TITLE
Update MAVSDK instantiation to new V2 API across documentation

### DIFF
--- a/en/cpp/guide/connections.md
+++ b/en/cpp/guide/connections.md
@@ -24,7 +24,7 @@ To add a serial connection (e.g. over USB, FTDI, or an SiK radio), you specify t
 **On Linux:**
 
 ```cpp
-Mavsdk mavsdk;
+Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 ConnectionResult connection_result = mavsdk.add_any_connection("serial:///dev/serial/by-id/usb-FTDI_FT232R_USB_UART_XXXXXXXX-if00-port0:57600");
 if (connection_result != ConnectionResult::Success) {
     std::cout << "Adding connection failed: " << connection_result << '\n';
@@ -35,7 +35,7 @@ if (connection_result != ConnectionResult::Success) {
 **On Windows:**
 
 ```cpp
-Mavsdk mavsdk;
+Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
 ConnectionResult connection_result = mavsdk.add_any_connection("serial://COM3:57600");
 if (connection_result != ConnectionResult::Success) {
     std::cout << "Adding connection failed: " << connection_result << '\n';

--- a/en/cpp/guide/follow_me.md
+++ b/en/cpp/guide/follow_me.md
@@ -38,7 +38,7 @@ The main steps are:
    For example (basic code without error checking):
    ```
    #include <mavsdk/mavsdk.h>
-   Mavsdk mavsdk;
+   Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
    ConnectionResult conn_result = mavsdk.add_udp_connection();
    // Wait for the system to connect via heartbeat
    while (mavsdk.system().size() == 0) {

--- a/en/cpp/guide/missions.md
+++ b/en/cpp/guide/missions.md
@@ -55,7 +55,7 @@ The main steps are:
    For example (basic code without error checking):
    ```
    #include <mavsdk/mavsdk.h>
-   Mavsdk mavsdk;
+   Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
    ConnectionResult conn_result = mavsdk.add_udp_connection();
    // Wait for the system to connect via heartbeat
    while (mavsdk.system().size() == 0) {

--- a/en/cpp/guide/offboard.md
+++ b/en/cpp/guide/offboard.md
@@ -34,7 +34,7 @@ The main steps are:
 1. [Create a connection](../guide/connections.md) to a `system`. For example (basic code without error checking):
    ```
    #include <mavsdk/mavsdk.h>
-   Mavsdk mavsdk;
+   Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
    ConnectionResult conn_result = mavsdk.add_udp_connection();
    // Wait for the system to connect via heartbeat
    while (mavsdk.system().size() == 0) {

--- a/en/cpp/guide/taking_off_landing.md
+++ b/en/cpp/guide/taking_off_landing.md
@@ -32,7 +32,7 @@ The main steps are:
 1. [Create a connection](../guide/connections.md) to a `system`. For example (basic code without error checking):
    ```
    #include <mavsdk/mavsdk.h>
-   Mavsdk mavsdk;
+   Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
    ConnectionResult conn_result = mavsdk.add_udp_connection();
    // Wait for the system to connect via heartbeat
    while (mavsdk.system().size() == 0) {

--- a/en/cpp/guide/telemetry.md
+++ b/en/cpp/guide/telemetry.md
@@ -67,7 +67,7 @@ The main steps are:
 1. [Create a connection](../guide/connections.md) to a `system`. For example (basic code without error checking):
    ```
    #include <mavsdk/mavsdk.h>
-   Mavsdk mavsdk;
+   Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};
    ConnectionResult conn_result = mavsdk.add_udp_connection();
    // Wait for the system to connect via heartbeat
    while (mavsdk.system().size() == 0) {


### PR DESCRIPTION
- Updated MAVSDK instantiation to comply with V2 API changes across the following documentation files: missions.md, connections.md, follow_me.md, telemetry.md, offboard.md, taking_off_landing.md.
- Replaced old instantiation Mavsdk mavsdk; with the new instantiation Mavsdk mavsdk{Mavsdk::Configuration{Mavsdk::ComponentType::GroundStation}};.
- The Mavsdk class now requires a configuration to be passed as a constructor argument to specify the component type.
- Ensured all examples reflect the updated instantiation method for consistency and accuracy.