### PR TITLE
Remove redundant plugin library linking instructions from documentation

### DIFF
--- a/en/cpp/guide/follow_me.md
+++ b/en/cpp/guide/follow_me.md
@@ -20,20 +20,6 @@ Applications must get target position information from the underlying platform (
 
 The main steps are:
 
-1. Link the plugin library into your application.
-   Do this by adding `mavsdk_follow_me` to the `target_link_libraries` section of the app's *cmake* build definition file
-
-   ```cmake
-   find_package(MAVSDK REQUIRED)
-
-   target_link_libraries(your_application_name
-     MAVSDK::mavsdk
-     ...
-     MAVSDK::mavsdk_follow_me
-     ...
-   )
-   )
-   ```
 1. [Create a connection](../guide/connections.md) to a `system`.
    For example (basic code without error checking):
    ```

--- a/en/cpp/guide/missions.md
+++ b/en/cpp/guide/missions.md
@@ -38,19 +38,6 @@ Additionally, the following commands are supported only for mission import/downl
 
 The main steps are:
 
-1. Link the plugin library into your application.
-   Do this by adding `mavsdk_mission` to the `target_link_libraries` section of the app's *cmake* build definition file
-
-   ```cmake
-   find_package(MAVSDK REQUIRED)
-
-   target_link_libraries(your_application_name
-     MAVSDK::mavsdk
-     ...
-     MAVSDK::mavsdk_mission
-     ...
-   )
-   ```
 1. [Create a connection](../guide/connections.md) to a `system`.
    For example (basic code without error checking):
    ```

--- a/en/cpp/guide/offboard.md
+++ b/en/cpp/guide/offboard.md
@@ -18,19 +18,6 @@ If more precise control is required, clients can call the setpoint methods at wh
 
 The main steps are:
 
-1. Link the plugin library into your application.
-   Do this by adding `mavsdk_offboard` to the `target_link_libraries` section of the app's *cmake* build definition file
-
-   ```cmake
-   find_package(MAVSDK REQUIRED)
-
-   target_link_libraries(your_application_name
-     MAVSDK::mavsdk
-     ...
-     MAVSDK::mavsdk_offboard
-     ...
-   )
-   ```
 1. [Create a connection](../guide/connections.md) to a `system`. For example (basic code without error checking):
    ```
    #include <mavsdk/mavsdk.h>

--- a/en/cpp/guide/taking_off_landing.md
+++ b/en/cpp/guide/taking_off_landing.md
@@ -16,19 +16,6 @@ General instructions are provided in the topic: [Using Plugins](../guide/using_p
 
 The main steps are:
 
-1. Link the plugin library into your application.
-   Do this by adding `mavsdk_action` to the `target_link_libraries` section of the app's *cmake* build definition file
-
-   ```cmake
-   find_package(MAVSDK REQUIRED)
-
-   target_link_libraries(your_application_name
-     MAVSDK::mavsdk
-     ...
-     MAVSDK::mavsdk_action
-     ...
-   )
-   ```
 1. [Create a connection](../guide/connections.md) to a `system`. For example (basic code without error checking):
    ```
    #include <mavsdk/mavsdk.h>

--- a/en/cpp/guide/telemetry.md
+++ b/en/cpp/guide/telemetry.md
@@ -51,19 +51,6 @@ General instructions are provided in the topic: [Using Plugins](../guide/using_p
 
 The main steps are:
 
-1. Link the plugin library into your application.
-   Do this by adding `mavsdk_telemetry` to the `target_link_libraries` section of the app's *cmake* build definition file
-
-   ```cmake
-    find_package(MAVSDK REQUIRED)
-
-   target_link_libraries(your_application_name
-     MAVSDK::mavsdk
-     ...
-     MAVSDK::mavsdk_telemetry
-     ...
-   )
-   ```
 1. [Create a connection](../guide/connections.md) to a `system`. For example (basic code without error checking):
    ```
    #include <mavsdk/mavsdk.h>

--- a/en/cpp/guide/using_plugins.md
+++ b/en/cpp/guide/using_plugins.md
@@ -7,17 +7,6 @@ A separate plugin instance must be created for each system that needs it.
 
 > **Note** All plugins are declared/used in the same way. This topic uses the `Action` plugin for the purposes of the demonstration.
 
-To use a plugin first link the plugin library into the application. Do this by adding it to the `target_link_libraries` section of the app's *cmake* build definition file:
-
-```cmake
-target_link_libraries(your_executable_name
-    mavsdk
-    ...
-    mavsdk_action
-   ...
-)
-```
-
 > **Note** Plugins are named using the convention **mavsdk\__plugin\_name_.so**.
   For more information see [Building C++ Apps](../guide/toolchain.md)
 


### PR DESCRIPTION
The sections regarding linking of plugin library were removed from the taking_off_landing.md, telemetry.md, follow_me.md, missions.md, offboard.md, using_plugins.md documentation files:

With recent versions of MAVSDK, you only need MAVSDK::mavsdk and hence these sections are removed.
