### PR TITLE
Fix data misalignment

### DIFF
--- a/en/cpp/api_reference/classmavsdk_1_1_mavsdk.md
+++ b/en/cpp/api_reference/classmavsdk_1_1_mavsdk.md
@@ -162,11 +162,8 @@ Value | Description
 <span id="classmavsdk_1_1_mavsdk_1ac9e9d48bbf840dad8705323b224b1746a6ca1d2b081cc474f42cb95e3d04e6e68"></span> `Autopilot` | SDK is used as an autopilot. 
 <span id="classmavsdk_1_1_mavsdk_1ac9e9d48bbf840dad8705323b224b1746af64f82089eddc6133add8c55c65d6687"></span> `GroundStation` | SDK is used as a ground station. 
 <span id="classmavsdk_1_1_mavsdk_1ac9e9d48bbf840dad8705323b224b1746a8f2f82e1a7aa48819e9530d5c4977477"></span> `CompanionComputer` | SDK is used as a companion computer on board the MAV. 
-<span id="classmavsdk_1_1_mavsdk_1ac9e9d48bbf840dad8705323b224b1746a967d35e40f3f95b1f538bd248640bf3b"></span> `Camera` |  
-<span id="classmavsdk_1_1_mavsdk_1ac9e9d48bbf840dad8705323b224b1746a90589c47f06eb971d548591f23c285af"></span> `Custom` | SDK is used as a camera. <
-
-
-the SDK is used in a custom configuration, no automatic ID will be provided
+<span id="classmavsdk_1_1_mavsdk_1ac9e9d48bbf840dad8705323b224b1746a967d35e40f3f95b1f538bd248640bf3b"></span> `Camera` |  SDK is used as a camera.
+<span id="classmavsdk_1_1_mavsdk_1ac9e9d48bbf840dad8705323b224b1746a90589c47f06eb971d548591f23c285af"></span> `Custom` |  SDK is used in a custom configuration, no automatic ID will be provided.
 
 ## Member Function Documentation
 


### PR DESCRIPTION
This commit corrects a minor formatting issue where few entries in the description column were shifted by one row. The data is now properly aligned.